### PR TITLE
Fix: prevent orchestrator re-evaluation from zeroing jailbreak counts

### DIFF
--- a/hackagent/attacks/evaluator/evaluation_step.py
+++ b/hackagent/attacks/evaluator/evaluation_step.py
@@ -756,7 +756,7 @@ class BaseEvaluationStep:
         - Add _run_id if missing
         - Ensure result_id exists
         - Build judge_keys
-        - Call _sync_to_server
+        - Call _sync_to_server (only if not already synced by the attack)
         """
         for idx, item in enumerate(evaluated_items):
             if "_run_id" not in item:
@@ -764,6 +764,14 @@ class BaseEvaluationStep:
             if "result_id" not in item:
                 # fallback to goal_id or generated UUID
                 item["result_id"] = item.get("goal_id") or str(uuid4())
+
+        # Skip server sync when results were already evaluated and synced
+        # by the attack technique's own pipeline.
+        if self._already_evaluated(evaluated_items):
+            self.logger.info(
+                "Results already synced by attack pipeline — skipping prepare_and_sync"
+            )
+            return
 
         # Build judge_keys automatically
         judge_keys = self._build_judge_keys_from_data(evaluated_items)
@@ -897,27 +905,71 @@ class BaseEvaluationStep:
                 evaluator_name=f"{evaluator_prefix}_{'_'.join(judges_used)}",
             )
 
+    # Keys whose presence signals that results were already evaluated
+    # by the attack technique's own pipeline (e.g. AdvPrefix aggregation).
+    _EVAL_SCORE_KEYS: frozenset = frozenset(
+        {
+            "best_score",
+            "success",
+            "eval_nj",
+            "eval_jb",
+            "eval_hb",
+            "eval_hbv",
+            "eval_nj_mean",
+            "eval_jb_mean",
+            "eval_hb_mean",
+            "eval_hbv_mean",
+            "pasr",
+        }
+    )
+
+    def _already_evaluated(self, data: List[Dict[str, Any]]) -> bool:
+        """Return True when *data* already carries evaluation scores.
+
+        Attack techniques (AdvPrefix, FlipAttack, etc.) run their own
+        judge evaluation inside ``run()``.  Re-evaluating those results
+        here is at best redundant and at worst destructive — e.g.
+        AdvPrefix aggregated rows lack the ``completion`` field, so
+        judges would evaluate an empty string and overwrite correct
+        statuses with FAILED_JAILBREAK.
+        """
+        if not data:
+            return False
+        sample = data[0]
+        if not isinstance(sample, dict):
+            return False
+        return bool(self._EVAL_SCORE_KEYS & sample.keys())
+
     def run_full_evaluation(self, input_data: List[Dict[str, Any]]):
-        # 1. Resolve judges
-        judges_config = self._resolve_judges_from_config()
-        evaluator_base_config = self._build_base_eval_config()
+        already_evaluated = self._already_evaluated(input_data)
 
-        # 2. Run evaluation
-        evaluated_items = self._run_evaluation(
-            input_data, judges_config, evaluator_base_config
-        )
+        if already_evaluated:
+            self.logger.info(
+                "Results already contain evaluation scores — "
+                "skipping redundant re-evaluation, generating metrics only"
+            )
+            evaluated_items = input_data
+        else:
+            # 1. Resolve judges
+            judges_config = self._resolve_judges_from_config()
+            evaluator_base_config = self._build_base_eval_config()
 
-        # 3. Enrich
-        self._enrich_items_with_scores(evaluated_items)
+            # 2. Run evaluation
+            evaluated_items = self._run_evaluation(
+                input_data, judges_config, evaluator_base_config
+            )
 
-        # 4. Logging
-        self._log_evaluation_asr(evaluated_items)
+            # 3. Enrich
+            self._enrich_items_with_scores(evaluated_items)
 
-        # 5. Tracker
-        self._update_tracker(evaluated_items)
+            # 4. Log ASR
+            self._log_evaluation_asr(evaluated_items)
 
-        # 6. Sync row-level results
-        self._sync_to_server(evaluated_items)
+            # 5. Tracker
+            self._update_tracker(evaluated_items)
+
+            # 6. Sync row-level results
+            self._sync_to_server(evaluated_items)
 
         # 7. Generate metrics summary
         summary = generate_summary_report(evaluated_items)


### PR DESCRIPTION
## Summary

Add `_already_evaluated` guard to `run_full_evaluation` and `prepare_and_sync` in `BaseEvaluationStep` that detects when input data already carries evaluation scores and skips redundant re-evaluation, while still generating the metrics summary.

Fixes #342

## Problem

The orchestrator calls `run_full_evaluation` after every attack's `run()` returns. All current attack techniques already evaluate inside their own `run()` method, so results arrive pre-evaluated.

For **AdvPrefix** this is destructive: the Aggregation/Selection stage drops the `completion` field and replaces it with `best_completion`. When `run_full_evaluation` normalizes the missing `completion` to `""`, judges evaluate empty strings, score everything 0, and `_sync_to_server` overwrites every Result record to `FAILED_JAILBREAK`.

## Solution

- Add `_EVAL_SCORE_KEYS` frozenset containing all known evaluation keys (`eval_jb`, `eval_hb`, `best_score`, `pasr`, etc.)
- Add `_already_evaluated()` method that checks the first row of input data for the presence of any known evaluation key
- Guard `run_full_evaluation`: when pre-evaluated, skip steps 1–6 (judge resolution, evaluation, enrichment, ASR logging, tracker update, row-level sync) but keep steps 7–8 (metrics summary generation and backend sync)
- Guard `prepare_and_sync`: skip server sync when results were already evaluated and synced by the attack technique's own pipeline

## Affected File

`hackagent/attacks/evaluator/evaluation_step.py`