### PR TITLE
✨ feat: possibility to enable or disable thinking with ollama

### DIFF
--- a/hackagent/agent.py
+++ b/hackagent/agent.py
@@ -66,6 +66,7 @@ class HackAgent:
         metadata: Optional[Dict[str, Any]] = None,
         target_config: Optional[Dict[str, Any]] = None,
         adapter_operational_config: Optional[Dict[str, Any]] = None,
+        thinking: Optional[bool] = None,
     ):
         """
         Initializes the HackAgent client and prepares it for interaction.
@@ -100,6 +101,10 @@ class HackAgent:
                 generation defaults such as `max_tokens`, `temperature`,
                 and `timeout`.
             adapter_operational_config: Optional configuration for the agent adapter.
+            thinking: Optional OLLAMA-only control for reasoning traces.
+                When set to `False`, requests sent through the target OLLAMA adapter
+                include `think: false` to disable thinking output. Ignored for
+                non-OLLAMA target agent types.
         """
 
         resolved_auth_token = utils.resolve_api_token(direct_api_key_param=api_key)
@@ -150,6 +155,16 @@ class HackAgent:
             **self.target_config,
             **(adapter_operational_config or {}),
         }
+
+        if processed_agent_type == AgentTypeEnum.OLLAMA:
+            if (
+                thinking is not None
+                and router_operational_config.get("thinking") is None
+            ):
+                router_operational_config["thinking"] = thinking
+        else:
+            # Keep `thinking` strictly OLLAMA-specific.
+            router_operational_config.pop("thinking", None)
 
         self.router = AgentRouter(
             backend=self.backend,

--- a/hackagent/attacks/evaluator/evaluation_step.py
+++ b/hackagent/attacks/evaluator/evaluation_step.py
@@ -385,6 +385,7 @@ class BaseEvaluationStep:
             "agent_type",
             "api_key",
             "api_key_env",
+            "thinking",
             "agent_metadata",
             "agent_name",
         ):

--- a/hackagent/attacks/shared/router_factory.py
+++ b/hackagent/attacks/shared/router_factory.py
@@ -61,6 +61,7 @@ _PASSTHROUGH_REQUEST_CONFIG_KEYS = (
     "logit_bias",
     "tools",
     "tool_choice",
+    "thinking",
 )
 
 
@@ -118,6 +119,24 @@ def create_router(
         env_key = os.environ.get(metadata_api_key)
         api_key = env_key if env_key else metadata_api_key
 
+    # ---- Agent type resolution ----
+    raw_agent_type = config.get("agent_type", "openai")
+    if isinstance(raw_agent_type, AgentTypeEnum):
+        agent_type = raw_agent_type
+    else:
+        agent_type_str = str(raw_agent_type)
+        normalized = _AGENT_TYPE_ALIASES.get(
+            agent_type_str.upper(), agent_type_str.upper()
+        )
+        try:
+            agent_type = AgentTypeEnum(normalized)
+        except ValueError:
+            log.warning(
+                f"Invalid agent_type '{agent_type_str}' for {name}, "
+                "defaulting to OPENAI_SDK"
+            )
+            agent_type = AgentTypeEnum.OPENAI_SDK
+
     # ---- Operational config ----
     operational_config: Dict[str, Any] = {
         "name": config.get("model", model_name),
@@ -135,17 +154,8 @@ def create_router(
         if key not in operational_config or operational_config[key] is None:
             operational_config[key] = value
 
-    # ---- Agent type resolution ----
-    agent_type_str = config.get("agent_type", "openai")
-    normalized = _AGENT_TYPE_ALIASES.get(agent_type_str.upper(), agent_type_str.upper())
-    try:
-        agent_type = AgentTypeEnum(normalized)
-    except ValueError:
-        log.warning(
-            f"Invalid agent_type '{agent_type_str}' for {name}, "
-            "defaulting to OPENAI_SDK"
-        )
-        agent_type = AgentTypeEnum.OPENAI_SDK
+    if agent_type != AgentTypeEnum.OLLAMA:
+        operational_config.pop("thinking", None)
 
     # ---- Create router ----
     log.debug(f"Creating AgentRouter for '{name}' ({model_name} via {endpoint})")

--- a/hackagent/attacks/techniques/config.py
+++ b/hackagent/attacks/techniques/config.py
@@ -79,6 +79,7 @@ class AttackerConfig(BaseModel):
     extra_body: Optional[Dict[str, Any]] = None
     response_format: Optional[Dict[str, Any]] = None
     logit_bias: Optional[Dict[str, int]] = None
+    thinking: Optional[bool] = None
 
 
 class CategoryClassifierConfig(BaseModel):
@@ -96,6 +97,7 @@ class CategoryClassifierConfig(BaseModel):
     api_key: Optional[str] = None
     max_tokens: int = DEFAULT_CATEGORY_CLASSIFIER_MAX_TOKENS
     temperature: float = 0.0
+    thinking: Optional[bool] = None
 
 
 class JudgeConfig(BaseModel):
@@ -120,6 +122,7 @@ class JudgeConfig(BaseModel):
     extra_body: Optional[Dict[str, Any]] = None
     response_format: Optional[Dict[str, Any]] = None
     logit_bias: Optional[Dict[str, int]] = None
+    thinking: Optional[bool] = None
 
 
 class JudgeEvalConfig(BaseModel):
@@ -152,6 +155,7 @@ class TargetConfig(BaseModel):
     response_format: Optional[Dict[str, Any]] = None
     logit_bias: Optional[Dict[str, int]] = None
     timeout: int = Field(default=120, ge=1)
+    thinking: Optional[bool] = None
 
 
 class GoalsDatasetConfig(BaseModel):

--- a/hackagent/attacks/techniques/pair/attack.py
+++ b/hackagent/attacks/techniques/pair/attack.py
@@ -251,6 +251,7 @@ class PAIRAttack(BaseAttack):
                 "identifier": attacker_config.get("identifier", "gemma3:4b"),
                 "endpoint": attacker_config.get("endpoint", "http://localhost:11434"),
                 "agent_type": attacker_config.get("agent_type", "OLLAMA"),
+                "thinking": attacker_config.get("thinking"),
                 "max_tokens": attacker_config.get("max_tokens", 500),
                 "temperature": attacker_config.get("temperature", 1.0),
                 "timeout": attacker_config.get(
@@ -299,6 +300,7 @@ class PAIRAttack(BaseAttack):
                 "identifier": scorer_config.get("identifier", "gemma3:4b"),
                 "endpoint": scorer_config.get("endpoint", "http://localhost:11434"),
                 "agent_type": scorer_config.get("agent_type", "OLLAMA"),
+                "thinking": scorer_config.get("thinking"),
                 "max_tokens": scorer_config.get("max_tokens", 4096),
                 "temperature": scorer_config.get("temperature", 0.7),
                 "timeout": scorer_config.get(

--- a/hackagent/router/adapters/ollama.py
+++ b/hackagent/router/adapters/ollama.py
@@ -55,6 +55,7 @@ class OllamaAgent(Agent):
     - 'top_k': Top-k sampling parameter (optional)
     - 'num_ctx': Context window size (optional)
     - 'stream': Whether to stream responses (default: False)
+    - 'thinking': Optional bool/level controlling Ollama think traces
     """
 
     ADAPTER_TYPE = "OllamaAgent"
@@ -76,6 +77,7 @@ class OllamaAgent(Agent):
                 - 'top_k' (optional): Default top_k sampling
                 - 'num_ctx' (optional): Context window size
                 - 'stream' (optional): Enable streaming (default: False)
+                - 'thinking' (optional): Forwarded as Ollama `think`
         """
         super().__init__(id, config)
 
@@ -98,6 +100,7 @@ class OllamaAgent(Agent):
         self.default_top_k = self._get_config_key("top_k")
         self.default_num_ctx = self._get_config_key("num_ctx")
         self.default_stream = self._get_config_key("stream", False)
+        self.default_thinking = self._get_config_key("thinking")
 
         # Request timeout
         self.timeout = self._get_config_key(
@@ -212,6 +215,7 @@ class OllamaAgent(Agent):
         options: Dict[str, Any],
         stream: bool = False,
         system: Optional[str] = None,
+        thinking: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Execute a generate request to Ollama's /api/generate endpoint.
@@ -236,6 +240,8 @@ class OllamaAgent(Agent):
 
         if system:
             payload["system"] = system
+        if thinking is not None:
+            payload["think"] = thinking
 
         self.logger.info(
             f"Sending generate request to Ollama model '{self.model_name}' at '{url}'"
@@ -272,6 +278,7 @@ class OllamaAgent(Agent):
         messages: List[Dict[str, str]],
         options: Dict[str, Any],
         stream: bool = False,
+        thinking: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Execute a chat request to Ollama's /api/chat endpoint.
@@ -292,6 +299,8 @@ class OllamaAgent(Agent):
             "stream": stream,
             "options": options,
         }
+        if thinking is not None:
+            payload["think"] = thinking
 
         self.logger.info(
             f"Sending chat request to Ollama model '{self.model_name}' at '{url}' "
@@ -340,6 +349,7 @@ class OllamaAgent(Agent):
                 - 'top_k' (optional): Override default top_k
                 - 'system' (optional): System prompt for generate endpoint
                 - 'stream' (optional): Enable streaming
+                - 'thinking' (optional): Forwarded as Ollama `think`
 
         Returns:
             A dictionary containing:
@@ -381,18 +391,27 @@ class OllamaAgent(Agent):
 
         stream = request_data.get("stream", self.default_stream)
         system = request_data.get("system")
+        thinking = request_data.get("thinking", self.default_thinking)
 
         try:
             if messages:
                 # Use chat endpoint
-                raw_response = self._execute_chat(messages, options, stream)
+                raw_response = self._execute_chat(
+                    messages, options, stream, thinking=thinking
+                )
                 # Chat response has message.content
                 processed_response = raw_response.get("message", {}).get("content", "")
             else:
                 # Use generate endpoint
                 if prompt is None:
                     raise ValueError("Prompt request resolved to None")
-                raw_response = self._execute_generate(prompt, options, stream, system)
+                raw_response = self._execute_generate(
+                    prompt,
+                    options,
+                    stream,
+                    system,
+                    thinking=thinking,
+                )
                 # Generate response has 'response' field
                 processed_response = raw_response.get("response", "")
 
@@ -408,6 +427,7 @@ class OllamaAgent(Agent):
                     "model_name": self.model_name,
                     "endpoint": self.api_base_url,
                     "invoked_options": options,
+                    "invoked_thinking": thinking,
                     "eval_count": raw_response.get("eval_count"),
                     "eval_duration": raw_response.get("eval_duration"),
                     "prompt_eval_count": raw_response.get("prompt_eval_count"),

--- a/hackagent/router/router.py
+++ b/hackagent/router/router.py
@@ -294,6 +294,7 @@ class AgentRouter:
                 "num_ctx",
                 "stream",
                 "timeout",
+                "thinking",
             ]
             if isinstance(self.backend_agent.metadata, dict):
                 for key in optional_ollama_keys:

--- a/tests/unit/adapters/test_ollama.py
+++ b/tests/unit/adapters/test_ollama.py
@@ -108,6 +108,15 @@ class TestOllamaAgentInit(unittest.TestCase):
         self.assertEqual(adapter.default_stream, False)
         self.assertEqual(adapter.timeout, 60)
 
+    def test_init_with_default_thinking(self):
+        """Test initialization stores default thinking behavior."""
+        adapter = OllamaAgent(
+            id="ollama_test_agent_thinking",
+            config={"name": "qwen3", "thinking": False},
+        )
+
+        self.assertFalse(adapter.default_thinking)
+
     def test_init_missing_name_raises_error(self):
         """Test that missing 'name' config raises error."""
         with self.assertRaisesRegex(
@@ -366,6 +375,51 @@ class TestOllamaAgentHandleRequest(unittest.TestCase):
         self.assertEqual(request_body["options"]["temperature"], 0.3)
         self.assertEqual(request_body["options"]["top_k"], 20)
         self.assertEqual(request_body["options"]["seed"], 42)
+
+    @patch("hackagent.router.adapters.ollama.requests.post")
+    def test_handle_request_forwards_thinking_override(self, mock_post):
+        """Per-request thinking is forwarded as Ollama `think`."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "model": "llama3",
+            "response": "Thinking disabled.",
+            "done": True,
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        response = self.adapter.handle_request({"prompt": "Hello", "thinking": False})
+
+        self.assertEqual(response["status_code"], 200)
+        request_body = mock_post.call_args[1]["json"]
+        self.assertIn("think", request_body)
+        self.assertFalse(request_body["think"])
+
+    @patch("hackagent.router.adapters.ollama.requests.post")
+    def test_handle_request_uses_default_thinking_from_config(self, mock_post):
+        """Adapter-level thinking default is applied when request omits it."""
+        adapter = OllamaAgent(
+            id="ollama_default_think",
+            config={"name": "llama3", "thinking": False},
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "model": "llama3",
+            "response": "Default thinking applied.",
+            "done": True,
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        response = adapter.handle_request({"prompt": "Hello"})
+
+        self.assertEqual(response["status_code"], 200)
+        request_body = mock_post.call_args[1]["json"]
+        self.assertIn("think", request_body)
+        self.assertFalse(request_body["think"])
 
 
 class TestOllamaAgentUtilityMethods(unittest.TestCase):

--- a/tests/unit/attacks/shared/test_router_factory.py
+++ b/tests/unit/attacks/shared/test_router_factory.py
@@ -238,3 +238,35 @@ class TestCreateRouter:
         assert operational_config["stop"] == ["END"]
         assert operational_config["response_format"] == {"type": "json_object"}
         assert operational_config["logit_bias"] == {"123": -100}
+
+    @patch("hackagent.attacks.shared.router_factory.AgentRouter")
+    def test_ollama_thinking_is_forwarded(
+        self, MockRouter, mock_client, basic_config, logger
+    ):
+        """thinking is forwarded for OLLAMA role configs."""
+        mock_instance = MagicMock()
+        mock_instance._agent_registry = {"key-1": MagicMock()}
+        MockRouter.return_value = mock_instance
+        basic_config["agent_type"] = "OLLAMA"
+        basic_config["thinking"] = False
+
+        create_router(mock_client, basic_config, logger, "test-router")
+
+        call_kwargs = MockRouter.call_args[1]
+        assert call_kwargs["adapter_operational_config"]["thinking"] is False
+
+    @patch("hackagent.attacks.shared.router_factory.AgentRouter")
+    def test_non_ollama_thinking_is_dropped(
+        self, MockRouter, mock_client, basic_config, logger
+    ):
+        """thinking is intentionally not forwarded to non-OLLAMA providers."""
+        mock_instance = MagicMock()
+        mock_instance._agent_registry = {"key-1": MagicMock()}
+        MockRouter.return_value = mock_instance
+        basic_config["agent_type"] = "OPENAI_SDK"
+        basic_config["thinking"] = False
+
+        create_router(mock_client, basic_config, logger, "test-router")
+
+        call_kwargs = MockRouter.call_args[1]
+        assert "thinking" not in call_kwargs["adapter_operational_config"]

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from hackagent.errors import HackAgentError
+from hackagent.router.types import AgentTypeEnum
 
 
 class TestHackAgentInitialization(unittest.TestCase):
@@ -115,6 +116,47 @@ class TestHackAgentInitialization(unittest.TestCase):
         self.assertEqual(call_kwargs["adapter_operational_config"]["temperature"], 0.4)
         self.assertEqual(call_kwargs["metadata"]["temperature"], 0.2)
         self.assertEqual(call_kwargs["metadata"]["label"], "demo")
+
+    @patch("hackagent.agent.AgentRouter")
+    @patch("hackagent.agent.utils.resolve_api_token", return_value="test-token")
+    @patch("hackagent.agent.utils.resolve_agent_type")
+    def test_constructor_thinking_is_forwarded_for_ollama(
+        self, mock_resolve_type, mock_resolve_token, mock_router
+    ):
+        """Constructor thinking is forwarded only when target type is OLLAMA."""
+        from hackagent.agent import HackAgent
+
+        mock_resolve_type.return_value = AgentTypeEnum.OLLAMA
+
+        HackAgent(
+            endpoint="http://localhost:11434",
+            api_key="test-key",
+            thinking=False,
+        )
+
+        call_kwargs = mock_router.call_args.kwargs
+        self.assertIn("thinking", call_kwargs["adapter_operational_config"])
+        self.assertFalse(call_kwargs["adapter_operational_config"]["thinking"])
+
+    @patch("hackagent.agent.AgentRouter")
+    @patch("hackagent.agent.utils.resolve_api_token", return_value="test-token")
+    @patch("hackagent.agent.utils.resolve_agent_type")
+    def test_constructor_thinking_is_ignored_for_non_ollama(
+        self, mock_resolve_type, mock_resolve_token, mock_router
+    ):
+        """Constructor thinking is stripped for non-OLLAMA target types."""
+        from hackagent.agent import HackAgent
+
+        mock_resolve_type.return_value = AgentTypeEnum.OPENAI_SDK
+
+        HackAgent(
+            endpoint="http://localhost:8000",
+            api_key="test-key",
+            thinking=False,
+        )
+
+        call_kwargs = mock_router.call_args.kwargs
+        self.assertNotIn("thinking", call_kwargs["adapter_operational_config"])
 
 
 class TestHackAgentAttackStrategies(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -2368,7 +2368,7 @@ wheels = [
 
 [[package]]
 name = "hackagent"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
For the target, if it is an Ollama agent, in the HackAgent constructor we can now specify a flag named `thinking`, e.g.
```
agent = HackAgent(
        name=TARGET_MODEL,
        endpoint=OLLAMA_BASE,
        agent_type=AgentTypeEnum.OLLAMA,
        thinking=False,
    )
```
For other roles, i.e. judges, attacker etc, if they are Ollama agents, we can now specify a field named `thinking`, e.g. 
```
JUDGES_LIST = [
    {
        "identifier": JUDGE_MODEL,
        "agent_type": AgentTypeEnum.OLLAMA,
        "endpoint": OLLAMA_BASE,
        "thinking": False,
        "api_key": os.getenv("OPENROUTER_API_KEY"),
        "type": "harmbench_variant",
    },
]
```