### PR TITLE
♻️ refactor: abandon requests in favor of httpx

### DIFF
--- a/docs/docs/datasets/custom-providers.md
+++ b/docs/docs/datasets/custom-providers.md
@@ -117,7 +117,7 @@ def load_goals(self, limit=None, **kwargs):
 ## Example: API Provider
 
 ```python
-import requests
+import httpx
 from hackagent.datasets import DatasetProvider, register_provider
 
 class APIProvider(DatasetProvider):
@@ -133,7 +133,7 @@ class APIProvider(DatasetProvider):
         headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
         params = {"limit": limit} if limit else {}
         
-        response = requests.get(
+        response = httpx.get(
             f"{self.base_url}/goals",
             headers=headers,
             params=params,

--- a/docs/docs/risks/evaluation-campaigns/custom-campaigns.md
+++ b/docs/docs/risks/evaluation-campaigns/custom-campaigns.md
@@ -423,7 +423,7 @@ jobs:
 ### Slack Notifications
 
 ```python
-import requests
+import httpx
 
 def send_slack_alert(campaign_name, results):
     """Send Slack notification for campaign results."""
@@ -450,7 +450,7 @@ def send_slack_alert(campaign_name, results):
             "short": False,
         })
 
-    requests.post(webhook_url, json=message)
+    httpx.post(webhook_url, json=message)
 ```
 
 ## Learn More

--- a/hackagent/examples/google_adk/jailbreak_eval/hack.py
+++ b/hackagent/examples/google_adk/jailbreak_eval/hack.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import time
 
-import requests
+import httpx
 
 from hackagent import HackAgent
 
@@ -91,12 +91,12 @@ def start_adk_server():
     # Wait for server to become healthy
     for _ in range(30):
         try:
-            r = requests.get(f"http://localhost:{PORT}/list-apps", timeout=2)
+            r = httpx.get(f"http://localhost:{PORT}/list-apps", timeout=2)
             if r.status_code == 200:
                 apps = r.json()
                 print(f"ADK server ready — discovered apps: {apps}")
                 return proc
-        except requests.ConnectionError:
+        except httpx.RequestError:
             pass
         time.sleep(1)
 

--- a/hackagent/examples/langchain/rag/agent_client.py
+++ b/hackagent/examples/langchain/rag/agent_client.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 
 # URL where the custom agent server is running
 API_URL = "http://localhost:8000/v1/chat/completions"
@@ -11,7 +11,7 @@ def ask_agent(question_text):
 
     try:
         print(f"Sending question: {question_text}")
-        response = requests.post(API_URL, json=payload, headers=headers)
+        response = httpx.post(API_URL, json=payload, headers=headers)
 
         if response.status_code == 200:
             data = response.json()

--- a/hackagent/router/providers/adk.py
+++ b/hackagent/router/providers/adk.py
@@ -20,7 +20,7 @@ import uuid
 from hackagent.logger import get_logger
 from typing import Any, Dict, List, Optional
 
-import requests
+import httpx
 
 from hackagent.router import envelope as _envelope
 from hackagent.router.agent import (
@@ -178,7 +178,7 @@ def _get_adk_custom_llm_class():
             payload = initial_state or {}
             session_timeout = min(30, max(1, int(self.timeout)))
             try:
-                response = requests.post(
+                response = httpx.post(
                     url,
                     headers=headers,
                     json=payload,
@@ -186,7 +186,7 @@ def _get_adk_custom_llm_class():
                 )
                 response.raise_for_status()
                 return
-            except requests.exceptions.HTTPError as http_err:
+            except httpx.HTTPStatusError as http_err:
                 response_text = ""
                 status_code = None
                 if http_err.response is not None:
@@ -206,7 +206,7 @@ def _get_adk_custom_llm_class():
                     f"HTTP Error {status_code} creating session "
                     f"{session_id}: {response_text[:200]}"
                 ) from http_err
-            except requests.exceptions.RequestException as e:
+            except httpx.RequestError as e:
                 raise AgentInteractionError(
                     f"Request failed creating session {session_id}: {e}"
                 ) from e
@@ -228,18 +228,18 @@ def _get_adk_custom_llm_class():
             }
 
             try:
-                response = requests.post(
+                response = httpx.post(
                     url, headers=headers, json=payload, timeout=self.timeout
                 )
-            except requests.exceptions.Timeout as e:
+            except httpx.TimeoutException as e:
                 raise AgentInteractionError(f"Request timed out: {e}") from e
-            except requests.exceptions.RequestException as e:
+            except httpx.RequestError as e:
                 raise AgentInteractionError(f"Request failed: {e}") from e
 
             response_body = response.text
             try:
                 response.raise_for_status()
-            except requests.exceptions.HTTPError as http_err:
+            except httpx.HTTPStatusError as http_err:
                 raise AgentInteractionError(
                     f"HTTP Error: {response.status_code}"
                 ) from http_err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "requests>=2.31.0",
     "httpx>=0.27.0",
     "pydantic[email]>=2.0",
     "litellm>=1.69.2",
@@ -63,7 +62,6 @@ docs = [
     "pydoc-markdown>=4.8.2",
     "toml>=0.10.2",
     "packaging>=24,<27",
-    "requests>=2.31.0",
 ]
 
 [project.scripts]

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -4,7 +4,7 @@
 import os
 
 import pytest
-import requests
+import httpx
 
 
 @pytest.mark.e2e
@@ -22,5 +22,5 @@ def test_auth_endpoint():
         "accept": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
-    response = requests.get(f"{base_url}/api/v1/auth", headers=headers)
+    response = httpx.get(f"{base_url}/api/v1/auth", headers=headers)
     assert response.status_code == 200

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,6 +36,7 @@ import atexit
 import logging
 from typing import Any, Dict, Generator, Optional
 
+import httpx
 import pytest
 
 # Configure logging for tests
@@ -193,15 +194,13 @@ def ollama_model() -> str:
 @pytest.fixture(scope="session")
 def ollama_available(ollama_base_url: str, ollama_model: str) -> bool:
     """Check if Ollama is available and the required model is loaded."""
-    import requests
-
     try:
-        response = requests.get(f"{ollama_base_url}/api/tags", timeout=5)
+        response = httpx.get(f"{ollama_base_url}/api/tags", timeout=5)
         if response.status_code != 200:
             return False
         models = response.json().get("models", [])
         return any(m.get("name", "").startswith(ollama_model) for m in models)
-    except requests.exceptions.RequestException:
+    except httpx.RequestError:
         return False
 
 
@@ -404,7 +403,6 @@ def adk_server_with_ollama(
 
     # Wait for server to start
     server_url = f"http://127.0.0.1:{port}"
-    import requests
 
     max_wait = 30  # seconds
     start_time = time.time()
@@ -412,12 +410,12 @@ def adk_server_with_ollama(
 
     while time.time() - start_time < max_wait:
         try:
-            response = requests.get(f"{server_url}/list-apps", timeout=2)
+            response = httpx.get(f"{server_url}/list-apps", timeout=2)
             if response.status_code == 200:
                 server_ready = True
                 logger.info(f"ADK server started successfully on {server_url}")
                 break
-        except requests.exceptions.RequestException:
+        except httpx.RequestError:
             pass
 
         # Check if process has died
@@ -469,13 +467,12 @@ def google_adk_available(google_adk_agent_url: Optional[str]) -> bool:
     """Check if Google ADK agent is available."""
     if not google_adk_agent_url:
         return False
-    import requests
 
     try:
         # Try to reach the ADK endpoint
-        response = requests.get(f"{google_adk_agent_url}", timeout=5)
+        response = httpx.get(f"{google_adk_agent_url}", timeout=5)
         return response.status_code in (200, 404)  # 404 is OK - server is up
-    except requests.exceptions.RequestException:
+    except httpx.RequestError:
         return False
 
 

--- a/tests/unit/router/test_adk_agent.py
+++ b/tests/unit/router/test_adk_agent.py
@@ -15,7 +15,7 @@ import unittest
 import uuid
 from unittest.mock import MagicMock, patch
 
-import requests
+import httpx
 
 from hackagent.router.providers.adk import (
     ADKAgent,
@@ -28,6 +28,17 @@ from hackagent.router.providers.adk import (
 from hackagent.router.providers import adk as adk_provider_module
 
 logging.disable(logging.CRITICAL)
+
+
+def _make_httpx_http_status_error(
+    status_code: int, text: str = "boom"
+) -> httpx.HTTPStatusError:
+    """Build an HTTPStatusError with attached request/response for tests."""
+    request = httpx.Request("POST", "http://fake-adk.com")
+    response = httpx.Response(status_code, text=text, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP Error: {status_code}", request=request, response=response
+    )
 
 
 def _make_handler(**overrides):
@@ -96,7 +107,7 @@ class TestADKHelpers(unittest.TestCase):
 
 
 class TestADKCustomLLMTransport(unittest.TestCase):
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_create_session_success(self, mock_post):
         mock_post.return_value = MagicMock(
             status_code=200, raise_for_status=MagicMock()
@@ -107,7 +118,7 @@ class TestADKCustomLLMTransport(unittest.TestCase):
         self.assertEqual(kwargs["timeout"], 30)
         self.assertEqual(kwargs["json"], {})
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_create_session_with_initial_state(self, mock_post):
         mock_post.return_value = MagicMock(
             status_code=200, raise_for_status=MagicMock()
@@ -116,48 +127,46 @@ class TestADKCustomLLMTransport(unittest.TestCase):
         handler._create_session(session_id="abc", initial_state={"k": "v"})
         self.assertEqual(mock_post.call_args.kwargs["json"], {"k": "v"})
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_create_session_409_is_idempotent(self, mock_post):
         mock_resp = MagicMock(status_code=409)
-        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=mock_resp
-        )
+        mock_resp.raise_for_status.side_effect = _make_httpx_http_status_error(409)
         mock_post.return_value = mock_resp
         handler = _make_handler()
         handler._create_session(session_id="abc")  # no raise
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_create_session_400_with_already_exists_text_is_idempotent(self, mock_post):
         mock_resp = MagicMock(
             status_code=400,
             text="Session already exists for this user and app.",
         )
-        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=mock_resp
+        mock_resp.raise_for_status.side_effect = _make_httpx_http_status_error(
+            400, text="Session already exists for this user and app."
         )
         mock_post.return_value = mock_resp
         handler = _make_handler()
         handler._create_session(session_id="abc")
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_create_session_other_http_error_raises(self, mock_post):
         mock_resp = MagicMock(status_code=500, text="boom")
-        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=mock_resp
-        )
+        mock_resp.raise_for_status.side_effect = _make_httpx_http_status_error(500)
         mock_post.return_value = mock_resp
         handler = _make_handler()
         with self.assertRaises(AgentInteractionError):
             handler._create_session(session_id="abc")
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_create_session_connection_error_raises(self, mock_post):
-        mock_post.side_effect = requests.exceptions.ConnectionError("nope")
+        mock_post.side_effect = httpx.RequestError(
+            "nope", request=httpx.Request("POST", "http://fake-adk.com")
+        )
         handler = _make_handler()
         with self.assertRaises(AgentInteractionError):
             handler._create_session(session_id="abc")
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_run_returns_final_text_from_events(self, mock_post):
         events = [
             {"content": {"parts": [{"text": "ignored"}]}},
@@ -246,7 +255,7 @@ class TestADKAgentHandleRequest(unittest.TestCase):
         response = self.adapter.handle_request({})
         self.assertEqual(response["status_code"], 400)
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_handle_request_success_routes_through_adk(self, mock_post):
         # First call creates the session; second call is /run.
         session_resp = MagicMock(status_code=200, raise_for_status=MagicMock())
@@ -265,7 +274,7 @@ class TestADKAgentHandleRequest(unittest.TestCase):
         self.assertEqual(agent_data.get("adk_events_list"), run_events)
         self.assertEqual(agent_data.get("adk_session_id"), self.adapter.session_id)
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_handle_request_uses_explicit_session_id(self, mock_post):
         session_resp = MagicMock(status_code=200, raise_for_status=MagicMock())
         run_resp = MagicMock(status_code=200, headers={}, text="[]")
@@ -284,13 +293,11 @@ class TestADKAgentHandleRequest(unittest.TestCase):
         session_call_url = mock_post.call_args_list[0][0][0]
         self.assertIn("/sessions/explicit-123", session_call_url)
 
-    @patch("requests.post")
+    @patch("httpx.post")
     def test_handle_request_run_http_error_returns_500(self, mock_post):
         session_resp = MagicMock(status_code=200, raise_for_status=MagicMock())
         run_resp = MagicMock(status_code=500, text="boom", headers={})
-        run_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=run_resp
-        )
+        run_resp.raise_for_status.side_effect = _make_httpx_http_status_error(500)
         mock_post.side_effect = [session_resp, run_resp]
         response = self.adapter.handle_request({"prompt": "hi"})
         self.assertEqual(response["status_code"], 500)

--- a/uv.lock
+++ b/uv.lock
@@ -2385,7 +2385,6 @@ dependencies = [
     { name = "pydantic", extra = ["email"] },
     { name = "python-dateutil" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "rich" },
     { name = "textual" },
 ]
@@ -2414,7 +2413,6 @@ dev = [
 docs = [
     { name = "packaging" },
     { name = "pydoc-markdown" },
-    { name = "requests" },
     { name = "toml" },
 ]
 
@@ -2431,7 +2429,6 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "textual", specifier = ">=1.0.0" },
 ]
@@ -2460,7 +2457,6 @@ dev = [
 docs = [
     { name = "packaging", specifier = ">=24,<27" },
     { name = "pydoc-markdown", specifier = ">=4.8.2" },
-    { name = "requests", specifier = ">=2.31.0" },
     { name = "toml", specifier = ">=0.10.2" },
 ]
 


### PR DESCRIPTION

## Summary
This PR removes the dual HTTP client setup and standardizes the repository on `httpx` only.  
The goal is to keep one transport stack, one error model, and one dependency surface across runtime code, tests, examples, and docs.

## What Changed
1. Migrated ADK runtime HTTP calls from `requests` to `httpx`.
2. Removed `requests` from project dependencies.
3. Updated tests that mocked or caught `requests` behavior to `httpx` equivalents.
4. Updated example scripts to use `httpx`.
5. Updated documentation snippets to use `httpx`.
6. Updated lockfile accordingly.

## Files Updated
- [hackagent/router/providers/adk.py](hackagent/router/providers/adk.py)
- [pyproject.toml](pyproject.toml)
- [uv.lock](uv.lock)
- [tests/unit/router/test_adk_agent.py](tests/unit/router/test_adk_agent.py)
- [tests/integration/conftest.py](tests/integration/conftest.py)
- [tests/e2e/test_auth.py](tests/e2e/test_auth.py)
- [hackagent/examples/google_adk/jailbreak_eval/hack.py](hackagent/examples/google_adk/jailbreak_eval/hack.py)
- [hackagent/examples/langchain/rag/agent_client.py](hackagent/examples/langchain/rag/agent_client.py)
- [docs/docs/datasets/custom-providers.md](docs/docs/datasets/custom-providers.md)
- [docs/docs/risks/evaluation-campaigns/custom-campaigns.md](docs/docs/risks/evaluation-campaigns/custom-campaigns.md)

## Behavior Notes
- No intended functional change in business logic.
- ADK request flow is unchanged; only transport library and exception classes were aligned:
1. `requests.exceptions.HTTPError` -> `httpx.HTTPStatusError`
2. `requests.exceptions.RequestException` / `ConnectionError` -> `httpx.RequestError`
3. `requests.exceptions.Timeout` -> `httpx.TimeoutException`

## Validation
1. Global search confirms no remaining `import requests` usage in the repository.
2. Focused ADK unit tests pass:
   - `uv run pytest -q tests/unit/router/test_adk_agent.py`
   - Result: `24 passed`

## Why This Is Better
1. Single HTTP stack across the codebase.
2. Consistent timeout/error handling semantics.
3. Lower maintenance overhead and fewer edge-case mismatches.
4. Better long-term alignment with modern sync/async-ready client patterns.

## Checklist
- [x] Runtime migrated to `httpx`
- [x] `requests` removed from dependencies
- [x] Lockfile updated
- [x] Tests migrated and validated
- [x] Docs/examples aligned