### PR TITLE
✨ feat: add url_json provider and two tool-use datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ HackAgent uses a modular pipeline to test agent robustness end-to-end.
 | **Generator** | LLM role that creates adversarial prompts to test the target agent |
 | **Judge** | LLM role that evaluates whether attacks bypass safety measures |
 | **Target Agent** | Your AI agent under test across supported frameworks |
-| **Datasets** | Pre-built benchmark presets plus custom HuggingFace/file datasets |
+| **Datasets** | Pre-built benchmark presets plus custom HuggingFace/file/URL JSON datasets |
 
 ## Supported Frameworks
 

--- a/docs/docs/datasets/huggingface.md
+++ b/docs/docs/datasets/huggingface.md
@@ -48,6 +48,7 @@ If this succeeds, your Hugging Face access is correctly configured.
 | `split` | string | No | `"test"` | Dataset split to use |
 | `name` | string | No | — | Configuration name (for multi-config datasets) |
 | `fallback_fields` | list | No | `["input", "prompt", "question", "text"]` | Alternative fields if primary not found |
+| `extra_fields` | list | No | `[]` | Additional fields to extract alongside each goal |
 | `trust_remote_code` | bool | No | `false` | Trust remote code execution |
 | `limit` | int | No | — | Maximum number of goals |
 | `shuffle` | bool | No | `false` | Randomize goal selection |
@@ -103,6 +104,33 @@ attack_config = {
         "fallback_fields": ["prompt", "instruction", "query"],  # Tried if "objective" not found
     }
 }
+```
+
+## Extracting Extra Metadata Fields
+
+If you need structured output (goal plus metadata), configure `extra_fields` and
+load with `return_dicts=True` via provider-level access:
+
+```python
+from hackagent.datasets import get_provider
+
+provider = get_provider(
+    "huggingface",
+    {
+        "path": "ai-safety-institute/AgentHarm",
+        "name": "harmful",
+        "goal_field": "prompt",
+        "split": "test_public",
+        "extra_fields": ["target_functions", "grading_function"],
+    },
+)
+
+rows = provider.load_goals(limit=5, return_dicts=True)
+extras = provider.get_extra_data()
+
+print(rows[0])
+# {"goal": "...", "target_functions": [...], "grading_function": "..."}
+print(extras[0])
 ```
 
 ## Remote Code Execution

--- a/docs/docs/datasets/index.md
+++ b/docs/docs/datasets/index.md
@@ -12,6 +12,7 @@ Instead of manually specifying `goals`, use the `dataset` parameter to load goal
 
 - 🎯 **Presets** — 30+ ready-to-use AI safety benchmarks (AgentHarm, JailbreakBench, BeaverTails, etc.)
 - 🤗 **HuggingFace Hub** — Any public or private dataset from HuggingFace
+- 🌐 **URL JSON** — Load remote JSON datasets directly from HTTPS URLs
 - 📁 **Local files** — JSON, JSONL, CSV, or TXT files from your filesystem
 - 🧭 **Intent taxonomy selection** — Pick OmniSafeBench categories/subcategories with `intents`
 
@@ -20,6 +21,7 @@ graph LR
     subgraph "Dataset Sources"
         P[🎯 Presets<br/>30+ Benchmarks] --> L[Dataset Loader]
         H[🤗 HuggingFace Hub<br/>Any Dataset] --> L
+        U[🌐 URL JSON<br/>Remote JSON Feeds] --> L
         F[📁 Local Files<br/>JSON/CSV/TXT] --> L
     end
     L --> G[Goals List]
@@ -27,6 +29,7 @@ graph LR
 
     style P fill:#e1f5ff
     style H fill:#fff4e1
+    style U fill:#e1fff4
     style F fill:#f0e1ff
     style L fill:#e8f5e9
 ```
@@ -79,7 +82,8 @@ results = agent.hack(attack_config=attack_config)
 ```
 
 :::tip Popular Presets
-- **`agentharm`** — AI agent safety (176+ tasks)
+- **`agentharm`** — AI agent safety (208 tasks)
+- **`agenthazard`** — tool-use risk prompts loaded from URL JSON
 - **`jailbreakbench`** — Curated jailbreaks (100 behaviors)
 - **`beavertails`** — Multi-category safety (330K+ samples)
 - **`simplesafetytests`** — Quick safety check (100 prompts)
@@ -130,7 +134,28 @@ attack_config = {
 results = agent.hack(attack_config=attack_config)
 ```
 
-### 4. Selecting Intent Categories (OmniSafeBench)
+### 4. Using URL JSON
+
+Load JSON datasets directly from a remote URL (no local file needed):
+
+```python
+attack_config = {
+    "attack_type": "baseline",
+    "dataset": {
+        "provider": "url_json",
+        "url": "https://yunhao-feng.github.io/AgentHazard/data/dataset.json",
+        "goal_field": "query",
+        "fallback_fields": ["prompt", "input", "text"],
+        "limit": 100,
+        "shuffle": True,
+        "seed": 42,
+    }
+}
+
+results = agent.hack(attack_config=attack_config)
+```
+
+### 5. Selecting Intent Categories (OmniSafeBench)
 
 When you want category-balanced goals without manually writing prompts, use
 `intents` to select categories and subcategories directly from the
@@ -192,6 +217,7 @@ When both `shuffle` and `offset` are used, shuffling happens **first**, then off
 |----------|-------------------|---------------|
 | **Presets** | 30+ benchmarks | 500K+ goals |
 | **HuggingFace** | Unlimited | Custom |
+| **URL JSON** | Any reachable JSON endpoint | Custom |
 | **Local Files** | Your data | Custom |
 
 ---
@@ -202,6 +228,7 @@ When both `shuffle` and `offset` are used, shuffling happens **first**, then off
 - 🧭 [**Selecting intent categories**](./selecting-intent-categories.md) — Use taxonomy categories/subcategories with strings, enums, or label codes
 - 🎯 [**Presets**](./presets.md) — All 30+ pre-configured benchmarks
 - 🤗 [**HuggingFace Provider**](./huggingface.md) — Load any HuggingFace dataset
+- 🌐 [**URL JSON Provider**](./url-json.md) — Load JSON datasets from remote URLs
 - 📁 [**File Provider**](./file.md) — Load from local JSON, CSV, or TXT files
 - 🔧 [**Custom Providers**](./custom-providers.md) — Create your own data sources
 - 🩺 [**Troubleshooting**](./troubleshooting.md) — Resolve common dataset loading issues

--- a/docs/docs/datasets/presets.md
+++ b/docs/docs/datasets/presets.md
@@ -34,17 +34,43 @@ Use `agentharm` for agent safety testing, `strongreject` for jailbreak evaluatio
 
 | Preset | Goals | Description |
 |--------|-------|-------------|
-| `agentharm` | 176+ | Harmful agentic tasks (public test split) |
-| `agentharm_benign` | — | Benign tasks for baseline comparison |
+| `agentharm` | 208 | Harmful agentic tasks (public test split) |
+| `agentharm_benign` | 208 | Benign tasks for baseline comparison |
 
 **Source:** [ai-safety-institute/AgentHarm](https://huggingface.co/datasets/ai-safety-institute/AgentHarm)
 **Use case:** Evaluating AI agents for harmful autonomous behaviors
+
+**Extra metadata fields available in preset config:**
+- `detailed_prompt`
+- `hint_included`
+- `target_functions`
+- `grading_function`
 
 ```python
 # Test agent against harmful agentic tasks
 attack_config = {
     "attack_type": "advprefix",
     "dataset": {"preset": "agentharm", "limit": 50},
+}
+```
+
+### AgentHazard
+
+**Tool-use risk prompts fetched from a remote JSON URL**
+
+| Preset | Goals | Description |
+|--------|-------|-------------|
+| `agenthazard` | 2,653 | AgentHazard prompts fetched in-memory from URL JSON |
+
+**Source:** [AgentHazard project page](https://yunhao-feng.github.io/AgentHazard)
+**Dataset URL:** `https://yunhao-feng.github.io/AgentHazard/data/dataset.json`
+**Use case:** Evaluating tool-use and decomposition-related risk patterns
+
+```python
+# Run with the built-in AgentHazard preset
+attack_config = {
+    "attack_type": "baseline",
+    "dataset": {"preset": "agenthazard", "limit": 100, "shuffle": True},
 }
 ```
 

--- a/docs/docs/datasets/url-json.md
+++ b/docs/docs/datasets/url-json.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 4
+---
+
+# URL JSON Provider
+
+Load attack goals from remote JSON endpoints directly into memory.
+
+:::tip When to Use
+Use the URL JSON provider when you:
+- Want to consume a dataset published as a JSON URL
+- Need a lightweight source without local files or HuggingFace setup
+- Evaluate dynamic/public benchmark feeds
+:::
+
+## Configuration Options
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `provider` | string | Yes | — | Must be `"url_json"` |
+| `url` | string | Yes | — | HTTPS URL returning JSON |
+| `goal_field` | string | No | `"instruction"` | Primary field containing the goal text |
+| `fallback_fields` | list | No | `["prompt", "input", "text"]` | Alternative fields if `goal_field` is missing |
+| `extra_fields` | list | No | `[]` | Additional fields to keep with each goal |
+| `limit` | int | No | — | Maximum number of goals |
+| `shuffle` | bool | No | `false` | Randomize goal selection |
+| `seed` | int | No | — | Random seed for reproducibility |
+
+---
+
+## Basic Usage
+
+```python
+attack_config = {
+    "attack_type": "baseline",
+    "dataset": {
+        "provider": "url_json",
+        "url": "https://yunhao-feng.github.io/AgentHazard/data/dataset.json",
+        "goal_field": "query",
+        "fallback_fields": ["prompt", "input", "text"],
+        "limit": 100,
+        "shuffle": True,
+        "seed": 42,
+    },
+}
+
+results = agent.hack(attack_config=attack_config)
+```
+
+---
+
+## Wrapped JSON Support
+
+The provider accepts both:
+- Top-level JSON arrays
+- JSON objects containing list keys like `data`, `samples`, `records`, or `items`
+
+Example payloads:
+
+```json
+[
+  {"query": "Goal A"},
+  {"query": "Goal B"}
+]
+```
+
+```json
+{
+  "records": [
+    {"query": "Goal A"},
+    {"query": "Goal B"}
+  ]
+}
+```
+
+---
+
+## Structured Output With Metadata
+
+When you need metadata alongside the goal text, use `extra_fields` and provider-level access:
+
+```python
+from hackagent.datasets import get_provider
+
+provider = get_provider(
+    "url_json",
+    {
+        "url": "https://yunhao-feng.github.io/AgentHazard/data/dataset.json",
+        "goal_field": "query",
+        "extra_fields": ["category", "decomposed_query", "jailbreak_method"],
+    },
+)
+
+rows = provider.load_goals(limit=5, return_dicts=True)
+extras = provider.get_extra_data()
+
+print(rows[0])
+print(extras[0])
+```
+
+---
+
+## Notes
+
+- The dataset is downloaded once and cached in memory per provider instance.
+- Use trusted URLs and pin sources when reproducibility is critical.
+- For static/private data, the [File Provider](./file.md) can be preferable.

--- a/docs/docs/hackagent/datasets/providers/url_json.md
+++ b/docs/docs/hackagent/datasets/providers/url_json.md
@@ -1,0 +1,66 @@
+---
+sidebar_label: url_json
+title: hackagent.datasets.providers.url_json
+---
+
+URL-based dataset provider for loading JSON datasets from the web.
+
+## UrlJsonDatasetProvider Objects
+
+```python
+class UrlJsonDatasetProvider(DatasetProvider)
+```
+
+Provider to download and load JSON datasets directly from a URL into RAM.
+
+#### __init__
+
+```python
+def __init__(config: Dict[str, Any])
+```
+
+Initialize the URL JSON dataset provider.
+
+**Arguments**:
+
+- `config` - Configuration dictionary with keys:
+  - url (str): Remote JSON URL
+  - goal_field (str, optional): Field containing the goal text (default: `instruction`)
+  - fallback_fields (list, optional): Alternative fields if goal_field is missing
+  - extra_fields (list, optional): Metadata fields to extract in parallel
+
+#### load_goals
+
+```python
+def load_goals(limit: Optional[int] = None,
+               shuffle: bool = False,
+               seed: Optional[int] = None,
+               return_dicts: bool = False,
+               **kwargs) -> Union[List[str], List[Dict[str, Any]]]
+```
+
+Load goals from the downloaded dataset.
+
+**Arguments**:
+
+- `limit` - Maximum number of goals to return.
+- `shuffle` - Whether to shuffle records before selecting.
+- `seed` - Random seed for shuffling.
+- `return_dicts` - Whether to return dictionaries with `goal` + `extra_fields`.
+- `**kwargs` - Additional arguments.
+
+#### get_extra_data
+
+```python
+def get_extra_data() -> List[Dict[str, Any]]
+```
+
+Return extra fields extracted during the last `load_goals` call.
+
+#### get_metadata
+
+```python
+def get_metadata() -> Dict[str, Any]
+```
+
+Return metadata about the loaded dataset.

--- a/docs/docs/introduction.mdx
+++ b/docs/docs/introduction.mdx
@@ -225,7 +225,7 @@ HackAgent is built with a modular architecture that makes it easy to test any AI
 | **Generator** | LLM that creates adversarial prompts to test the target agent |
 | **Judge** | LLM that evaluates whether attacks successfully bypassed safety measures |
 | **Target Agent** | Your AI agent being tested (supports multiple frameworks) |
-| **Datasets** | Pre-built benchmark presets plus custom HuggingFace/file datasets |
+| **Datasets** | Pre-built benchmark presets plus custom HuggingFace/file/URL JSON datasets |
 
 
 ---

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -95,6 +95,7 @@ const sidebars: SidebarsConfig = {
         'datasets/selecting-intent-categories',
         'datasets/presets',
         'datasets/huggingface',
+        'datasets/url-json',
         'datasets/file',
         'datasets/custom-providers',
         'datasets/troubleshooting',
@@ -236,6 +237,7 @@ const sidebars: SidebarsConfig = {
             'hackagent/datasets/registry',
             'hackagent/datasets/providers/file',
             'hackagent/datasets/providers/huggingface',
+            'hackagent/datasets/providers/url_json',
           ],
         },
         {

--- a/hackagent/attacks/orchestrator.py
+++ b/hackagent/attacks/orchestrator.py
@@ -460,6 +460,8 @@ class AttackOrchestrator:
         dataset_config = attack_config.get("dataset")
         intents_config = attack_config.get("intents")
         goal_labels_by_index: Optional[Dict[int, Dict[str, str]]] = None
+        goal_extra_fields_by_index: Optional[Dict[int, Dict[str, Any]]] = None
+        goal_extra_fields_by_goal: Optional[Dict[str, Dict[str, Any]]] = None
 
         if goals is not None and dataset_config is not None:
             logger.warning(
@@ -480,7 +482,9 @@ class AttackOrchestrator:
             goals, goal_labels_by_index = self._load_goals_from_intents(intents_config)
         elif dataset_config is not None:
             # Load goals from dataset source
-            goals = self._load_goals_from_dataset(dataset_config)
+            goals, goal_extra_fields_by_index = self._load_goals_from_dataset(
+                dataset_config
+            )
         elif goals is None:
             raise ValueError(
                 f"'{self.attack_type}' requires either 'goals' (list), "
@@ -497,6 +501,25 @@ class AttackOrchestrator:
         params: Dict[str, Any] = {"goals": goals}
         if goal_labels_by_index:
             params["_goal_labels_by_index"] = goal_labels_by_index
+        if goal_extra_fields_by_index:
+            params["_goal_extra_fields_by_index"] = goal_extra_fields_by_index
+            by_goal: Dict[str, Dict[str, Any]] = {}
+            for idx, metadata in goal_extra_fields_by_index.items():
+                if not isinstance(idx, int) or not isinstance(metadata, dict):
+                    continue
+                if idx < 0 or idx >= len(goals):
+                    continue
+                goal_text = goals[idx]
+                if (
+                    isinstance(goal_text, str)
+                    and goal_text
+                    and goal_text not in by_goal
+                ):
+                    by_goal[goal_text] = metadata
+            if by_goal:
+                goal_extra_fields_by_goal = by_goal
+        if goal_extra_fields_by_goal:
+            params["_goal_extra_fields_by_goal"] = goal_extra_fields_by_goal
         return params
 
     @staticmethod
@@ -1263,7 +1286,9 @@ class AttackOrchestrator:
 
         return None
 
-    def _load_goals_from_dataset(self, dataset_config: Dict[str, Any]) -> list:
+    def _load_goals_from_dataset(
+        self, dataset_config: Dict[str, Any]
+    ) -> Tuple[List[str], Dict[int, Dict[str, Any]]]:
         """
         Load goals from a dataset configuration.
 
@@ -1284,20 +1309,24 @@ class AttackOrchestrator:
                 - seed (int, optional): Random seed for shuffling
 
         Returns:
-            List of goal strings
+            Tuple of:
+                - List of goal strings
+                - Per-goal metadata map (index -> metadata dict)
 
         Raises:
             ValueError: If dataset configuration is invalid
             ImportError: If required dependencies are not available
         """
-        from hackagent.datasets import load_goals_from_config
+        from hackagent.datasets import load_goals_and_extra_fields_from_config
 
         logger.info(f"Loading goals from dataset: {dataset_config}")
 
         try:
-            goals = load_goals_from_config(dataset_config)
+            goals, goal_extra_fields_by_index = load_goals_and_extra_fields_from_config(
+                dataset_config
+            )
             logger.info(f"Loaded {len(goals)} goals from dataset")
-            return goals
+            return goals, goal_extra_fields_by_index
         except Exception as e:
             logger.error(f"Failed to load goals from dataset: {e}", exc_info=True)
             raise ValueError(f"Failed to load goals from dataset: {e}") from e
@@ -1637,6 +1666,12 @@ class AttackOrchestrator:
         # 1. Validate parameters
         attack_params = self._prepare_attack_params(attack_config)
         goal_labels_by_index = attack_params.pop("_goal_labels_by_index", None)
+        goal_extra_fields_by_index = attack_params.pop(
+            "_goal_extra_fields_by_index", None
+        )
+        goal_extra_fields_by_goal = attack_params.pop(
+            "_goal_extra_fields_by_goal", None
+        )
 
         # Fail-fast preflight before creating Attack/Run DB records.
         # Skip this when intents already provide explicit category labels.
@@ -1727,6 +1762,17 @@ class AttackOrchestrator:
                 **attack_config,
                 "_goal_labels_by_index": goal_labels_by_index,
                 "_disable_goal_category_classifier": True,
+            }
+
+        if goal_extra_fields_by_index:
+            attack_config = {
+                **attack_config,
+                "_goal_extra_fields_by_index": goal_extra_fields_by_index,
+            }
+        if goal_extra_fields_by_goal:
+            attack_config = {
+                **attack_config,
+                "_goal_extra_fields_by_goal": goal_extra_fields_by_goal,
             }
 
         # Make the event bus available to the technique impl and to the

--- a/hackagent/attacks/techniques/base.py
+++ b/hackagent/attacks/techniques/base.py
@@ -246,6 +246,28 @@ class BaseAttack(abc.ABC):
         """
         run_id = self.config.get("_run_id") or self.run_id
         backend = self.config.get("_backend") or self.backend
+
+        # Optional per-goal metadata injected by the orchestrator when dataset
+        # providers expose extra fields (e.g., AgentHazard/AgentHarm metadata).
+        goal_metadata_by_index = self.config.get("_goal_extra_fields_by_index")
+        goal_metadata_by_goal = self.config.get("_goal_extra_fields_by_goal")
+        if (
+            isinstance(goal_metadata_by_index, dict)
+            and goal_metadata_by_index
+            or isinstance(goal_metadata_by_goal, dict)
+            and goal_metadata_by_goal
+        ):
+            merged_initial_metadata = dict(initial_metadata or {})
+            if isinstance(goal_metadata_by_index, dict) and goal_metadata_by_index:
+                merged_initial_metadata["_goal_metadata_by_index"] = (
+                    goal_metadata_by_index
+                )
+            if isinstance(goal_metadata_by_goal, dict) and goal_metadata_by_goal:
+                merged_initial_metadata["_goal_metadata_by_goal"] = (
+                    goal_metadata_by_goal
+                )
+            initial_metadata = merged_initial_metadata
+
         raw_run_start_time = self.config.get("_global_run_start_time")
         run_start_time: Optional[float]
         try:

--- a/hackagent/datasets/__init__.py
+++ b/hackagent/datasets/__init__.py
@@ -41,6 +41,8 @@ from hackagent.datasets.presets import PRESETS, get_preset, list_presets
 from hackagent.datasets.registry import (
     get_provider,
     load_goals,
+    load_goals_and_extra_fields,
+    load_goals_and_extra_fields_from_config,
     load_goals_from_config,
     register_provider,
 )
@@ -55,6 +57,8 @@ __all__ = [
     "load_goals_from_intents_config",
     "list_presets",
     "load_goals",
+    "load_goals_and_extra_fields",
     "load_goals_from_config",
+    "load_goals_and_extra_fields_from_config",
     "register_provider",
 ]

--- a/hackagent/datasets/presets.py
+++ b/hackagent/datasets/presets.py
@@ -25,7 +25,7 @@ PRESETS: Dict[str, Dict[str, Any]] = {
         "goal_field": "prompt",
         "split": "test_public",
         "fallback_fields": ["input", "text"],
-        "description": "AgentHarm benchmark - 176+ harmful agentic tasks (public split)",
+        "description": "AgentHarm benchmark - 208 harmful agentic tasks (public split)",
         "extra_fields": [
             "detailed_prompt",
             "hint_included",
@@ -40,7 +40,7 @@ PRESETS: Dict[str, Dict[str, Any]] = {
         "goal_field": "prompt",
         "split": "test_public_benign",
         "fallback_fields": ["input", "text"],
-        "description": "AgentHarm benchmark - benign tasks for comparison",
+        "description": "AgentHarm benchmark - 208 benign tasks for comparison",
     },
     # =========================================================================
     # AgentHazard - In-memory JSON dataset from URL
@@ -56,7 +56,7 @@ PRESETS: Dict[str, Dict[str, Any]] = {
             "decomposed_query",
             "jailbreak_method",
         ],  # Specify any metadata fields to extract
-        "description": "AgentHazard dataset fetched directly into RAM",
+        "description": "AgentHazard dataset - 2653 goals fetched directly into RAM",
     },
     # =========================================================================
     # StrongREJECT - Jailbreak evaluation

--- a/hackagent/datasets/presets.py
+++ b/hackagent/datasets/presets.py
@@ -26,6 +26,12 @@ PRESETS: Dict[str, Dict[str, Any]] = {
         "split": "test_public",
         "fallback_fields": ["input", "text"],
         "description": "AgentHarm benchmark - 176+ harmful agentic tasks (public split)",
+        "extra_fields": [
+            "detailed_prompt",
+            "hint_included",
+            "target_functions",
+            "grading_function",
+        ],
     },
     "agentharm_benign": {
         "provider": "huggingface",
@@ -35,6 +41,22 @@ PRESETS: Dict[str, Dict[str, Any]] = {
         "split": "test_public_benign",
         "fallback_fields": ["input", "text"],
         "description": "AgentHarm benchmark - benign tasks for comparison",
+    },
+    # =========================================================================
+    # AgentHazard - In-memory JSON dataset from URL
+    # Source: https://yunhao-feng.github.io/AgentHazard
+    # =========================================================================
+    "agenthazard": {
+        "provider": "url_json",
+        "url": "https://yunhao-feng.github.io/AgentHazard/data/dataset.json",
+        "goal_field": "query",  # The AgentHazard JSON uses 'query' as the main prompt
+        "fallback_fields": ["prompt", "input", "text"],
+        "extra_fields": [
+            "category",
+            "decomposed_query",
+            "jailbreak_method",
+        ],  # Specify any metadata fields to extract
+        "description": "AgentHazard dataset fetched directly into RAM",
     },
     # =========================================================================
     # StrongREJECT - Jailbreak evaluation

--- a/hackagent/datasets/providers/__init__.py
+++ b/hackagent/datasets/providers/__init__.py
@@ -5,8 +5,10 @@
 
 from hackagent.datasets.providers.file import FileDatasetProvider
 from hackagent.datasets.providers.huggingface import HuggingFaceDatasetProvider
+from hackagent.datasets.providers.url_json import UrlJsonDatasetProvider
 
 __all__ = [
     "FileDatasetProvider",
     "HuggingFaceDatasetProvider",
+    "UrlJsonDatasetProvider",
 ]

--- a/hackagent/datasets/providers/huggingface.py
+++ b/hackagent/datasets/providers/huggingface.py
@@ -55,6 +55,9 @@ class HuggingFaceDatasetProvider(DatasetProvider):
         )
         self.trust_remote_code = config.get("trust_remote_code", False)
 
+        self.extra_fields = config.get("extra_fields", [])
+        self.last_extracted_extras: List[Dict[str, Any]] = []
+
         self._dataset = None
         self._metadata = {
             "provider": "huggingface",
@@ -99,7 +102,7 @@ class HuggingFaceDatasetProvider(DatasetProvider):
         shuffle: bool = False,
         seed: Optional[int] = None,
         **kwargs,
-    ) -> List[str]:
+    ) -> List[Any]:
         """
         Load goals from the HuggingFace dataset.
 
@@ -121,6 +124,9 @@ class HuggingFaceDatasetProvider(DatasetProvider):
         goals = []
         count = 0
 
+        self.last_extracted_extras = []
+        return_dicts = kwargs.get("return_dicts", False)
+
         for record in dataset:
             if limit and count >= limit:
                 break
@@ -132,7 +138,18 @@ class HuggingFaceDatasetProvider(DatasetProvider):
             )
 
             if goal:
-                goals.append(goal)
+                extra_data = (
+                    {f: record.get(f) for f in self.extra_fields}
+                    if self.extra_fields
+                    else {}
+                )
+                self.last_extracted_extras.append(extra_data)
+
+                if return_dicts and self.extra_fields:
+                    goals.append({"goal": goal, **extra_data})
+                else:
+                    goals.append(goal)
+
                 count += 1
             else:
                 self.logger.warning(
@@ -144,6 +161,10 @@ class HuggingFaceDatasetProvider(DatasetProvider):
         self.logger.info(f"Extracted {len(goals)} goals from dataset")
 
         return goals
+
+    def get_extra_data(self) -> List[Dict[str, Any]]:
+        """Return extra fields extracted during the last load_goals call."""
+        return self.last_extracted_extras
 
     def get_metadata(self) -> Dict[str, Any]:
         """Return metadata about the loaded dataset."""

--- a/hackagent/datasets/providers/url_json.py
+++ b/hackagent/datasets/providers/url_json.py
@@ -1,0 +1,151 @@
+# Copyright 2026 - AI4I. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""URL-based dataset provider for loading JSON datasets from the web."""
+
+import json
+import urllib.request
+import random
+from typing import Any, Dict, List, Optional, Union
+from hackagent.logger import get_logger
+from hackagent.datasets.base import DatasetProvider
+
+logger = get_logger(__name__)
+
+
+class UrlJsonDatasetProvider(DatasetProvider):
+    """
+    Provider to download and load JSON datasets directly from a URL into RAM.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+
+        self.url = config.get("url")
+        if not self.url:
+            raise ValueError("URL is required in the configuration")
+
+        self.goal_field = config.get("goal_field", "instruction")
+        self.extra_fields = config.get("extra_fields", [])
+        self.fallback_fields = config.get(
+            "fallback_fields", ["prompt", "input", "text"]
+        )
+
+        # List to store additional metadata while maintaining backward compatibility
+        self.last_extracted_extras: List[Dict[str, Any]] = []
+
+        self._dataset = None
+        self._metadata = {
+            "provider": "url_json",
+            "url": self.url,
+            "goal_field": self.goal_field,
+            "extra_fields": self.extra_fields,
+        }
+
+    def _load_dataset(self):
+        """Lazily download and load the dataset from the specified URL."""
+        if self._dataset is not None:
+            return self._dataset
+
+        self.logger.info(f"Downloading dataset into memory from: {self.url}")
+
+        try:
+            # Basic headers to avoid being blocked by servers
+            req = urllib.request.Request(
+                self.url, headers={"User-Agent": "Mozilla/5.0"}
+            )
+            with urllib.request.urlopen(req) as response:
+                raw_data = response.read().decode("utf-8")
+                self._dataset = json.loads(raw_data)
+
+            # If the downloaded JSON is a dictionary (e.g., {"data": [...]}), extract the list
+            if isinstance(self._dataset, dict):
+                for key in ["data", "samples", "records", "items"]:
+                    if key in self._dataset and isinstance(self._dataset[key], list):
+                        self._dataset = self._dataset[key]
+                        break
+
+            self._metadata["total_samples"] = len(self._dataset)
+            return self._dataset
+
+        except Exception as e:
+            self.logger.error(f"Error loading dataset from {self.url}: {e}")
+            raise
+
+    def load_goals(
+        self,
+        limit: Optional[int] = None,
+        shuffle: bool = False,
+        seed: Optional[int] = None,
+        return_dicts: bool = False,
+        **kwargs,
+    ) -> Union[List[str], List[Dict[str, Any]]]:
+        """
+        Load goals from the downloaded dataset.
+
+        Args:
+            limit: Maximum number of goals to return.
+            shuffle: Whether to shuffle the dataset before selecting.
+            seed: Random seed for shuffling.
+            return_dicts: If True, returns a list of dictionaries with extra fields.
+                          If False (default), returns a list of strings.
+            **kwargs: Additional arguments.
+
+        Returns:
+            List of goal strings by default, or dictionaries if return_dicts=True.
+        """
+        dataset = self._load_dataset()
+
+        # Shuffle logic for lists
+        if shuffle:
+            # Create a copy so we don't modify the cached dataset in place
+            dataset = list(dataset)
+            if seed is not None:
+                random.seed(seed)
+            random.shuffle(dataset)
+
+        goals = []
+        self.last_extracted_extras = []
+        count = 0
+
+        for record in dataset:
+            if limit and count >= limit:
+                break
+
+            goal = self._extract_goal_from_record(
+                record, self.goal_field, self.fallback_fields
+            )
+
+            if goal:
+                extra_data = {}
+                if self.extra_fields:
+                    extra_data = {
+                        field: record.get(field) for field in self.extra_fields
+                    }
+
+                # Always save extra data to parallel list
+                self.last_extracted_extras.append(extra_data)
+
+                if return_dicts and self.extra_fields:
+                    goals.append({"goal": goal, **extra_data})
+                else:
+                    goals.append(goal)
+                count += 1
+            else:
+                self.logger.warning(
+                    f"Could not extract goal from record. "
+                    f"Tried fields: {[self.goal_field] + self.fallback_fields}"
+                )
+
+        self._metadata["goals_loaded"] = len(goals)
+        self.logger.info(f"Extracted {len(goals)} goals from URL dataset")
+
+        return goals
+
+    def get_extra_data(self) -> List[Dict[str, Any]]:
+        """Return the extra fields extracted during the last load_goals call."""
+        return self.last_extracted_extras
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Return metadata about the loaded dataset."""
+        return self._metadata.copy()

--- a/hackagent/datasets/registry.py
+++ b/hackagent/datasets/registry.py
@@ -55,6 +55,59 @@ def get_provider(name: str, config: Dict[str, Any]) -> DatasetProvider:
     return _PROVIDERS[name_lower](config)
 
 
+def _resolve_provider_and_config(
+    # Preset-based loading
+    preset: Optional[str] = None,
+    # Direct provider loading
+    provider: Optional[str] = None,
+    path: Optional[str] = None,
+    goal_field: Optional[str] = None,
+    split: Optional[str] = None,
+    name: Optional[str] = None,
+    # Extra config
+    **kwargs,
+) -> tuple[str, Dict[str, Any]]:
+    """Resolve final provider name and config from preset/direct arguments."""
+    if preset:
+        # Use preset configuration
+        config = get_preset(preset)
+        provider_name = config.pop("provider", "huggingface")
+
+        # Override preset with any explicit arguments
+        if path:
+            config["path"] = path
+        if goal_field:
+            config["goal_field"] = goal_field
+        if split:
+            config["split"] = split
+        if name:
+            config["name"] = name
+
+        # Add any extra kwargs
+        config.update(kwargs)
+
+    elif provider:
+        # Build config from arguments
+        provider_name = provider
+        config = {
+            "path": path,
+            "goal_field": goal_field or "input",
+            **kwargs,
+        }
+        if split:
+            config["split"] = split
+        if name:
+            config["name"] = name
+
+    else:
+        raise ValueError(
+            "Either 'preset' or 'provider' must be specified. "
+            f"Available presets: {', '.join(sorted(PRESETS.keys()))}"
+        )
+
+    return provider_name, config
+
+
 def load_goals(
     # Preset-based loading
     preset: Optional[str] = None,
@@ -118,43 +171,15 @@ def load_goals(
     Raises:
         ValueError: If neither preset nor provider is specified.
     """
-    # Build configuration
-    if preset:
-        # Use preset configuration
-        config = get_preset(preset)
-        provider_name = config.pop("provider", "huggingface")
-
-        # Override preset with any explicit arguments
-        if path:
-            config["path"] = path
-        if goal_field:
-            config["goal_field"] = goal_field
-        if split:
-            config["split"] = split
-        if name:
-            config["name"] = name
-
-        # Add any extra kwargs
-        config.update(kwargs)
-
-    elif provider:
-        # Build config from arguments
-        provider_name = provider
-        config = {
-            "path": path,
-            "goal_field": goal_field or "input",
-            **kwargs,
-        }
-        if split:
-            config["split"] = split
-        if name:
-            config["name"] = name
-
-    else:
-        raise ValueError(
-            "Either 'preset' or 'provider' must be specified. "
-            f"Available presets: {', '.join(sorted(PRESETS.keys()))}"
-        )
+    provider_name, config = _resolve_provider_and_config(
+        preset=preset,
+        provider=provider,
+        path=path,
+        goal_field=goal_field,
+        split=split,
+        name=name,
+        **kwargs,
+    )
 
     # Get provider instance
     provider_instance = get_provider(provider_name, config)
@@ -165,6 +190,64 @@ def load_goals(
         shuffle=shuffle,
         seed=seed,
     )
+
+
+def load_goals_and_extra_fields(
+    # Preset-based loading
+    preset: Optional[str] = None,
+    # Direct provider loading
+    provider: Optional[str] = None,
+    path: Optional[str] = None,
+    goal_field: Optional[str] = None,
+    split: Optional[str] = None,
+    name: Optional[str] = None,
+    # Common options
+    limit: Optional[int] = None,
+    shuffle: bool = False,
+    seed: Optional[int] = None,
+    # Extra config
+    **kwargs,
+) -> tuple[List[str], Dict[int, Dict[str, Any]]]:
+    """Load goals and return per-goal extra fields metadata, when available."""
+    provider_name, config = _resolve_provider_and_config(
+        preset=preset,
+        provider=provider,
+        path=path,
+        goal_field=goal_field,
+        split=split,
+        name=name,
+        **kwargs,
+    )
+
+    provider_instance = get_provider(provider_name, config)
+    goals = provider_instance.load_goals(
+        limit=limit,
+        shuffle=shuffle,
+        seed=seed,
+    )
+
+    extra_by_index: Dict[int, Dict[str, Any]] = {}
+    get_extra_data = getattr(provider_instance, "get_extra_data", None)
+    if callable(get_extra_data):
+        try:
+            raw_extras = get_extra_data() or []
+            if isinstance(raw_extras, list):
+                for idx, extra in enumerate(raw_extras):
+                    if idx >= len(goals):
+                        break
+                    if not isinstance(extra, dict) or not extra:
+                        continue
+
+                    # Drop empty fields for cleaner dashboard rendering.
+                    filtered = {
+                        k: v for k, v in extra.items() if v not in (None, "", [], {})
+                    }
+                    if filtered:
+                        extra_by_index[idx] = {"extra_fields": filtered}
+        except Exception as exc:
+            logger.warning("Failed to collect dataset extra fields metadata: %s", exc)
+
+    return goals, extra_by_index
 
 
 def load_goals_from_config(config: Dict[str, Any]) -> List[str]:
@@ -209,6 +292,13 @@ def load_goals_from_config(config: Dict[str, Any]) -> List[str]:
     return load_goals(**config)
 
 
+def load_goals_and_extra_fields_from_config(
+    config: Dict[str, Any],
+) -> tuple[List[str], Dict[int, Dict[str, Any]]]:
+    """Load goals and extra fields from a dataset configuration dictionary."""
+    return load_goals_and_extra_fields(**config)
+
+
 # Register built-in providers on import
 def _register_builtin_providers():
     """Register the built-in dataset providers."""
@@ -231,7 +321,9 @@ __all__ = [
     "get_provider",
     "register_provider",
     "load_goals",
+    "load_goals_and_extra_fields",
     "load_goals_from_config",
+    "load_goals_and_extra_fields_from_config",
     "get_preset",
     "list_presets",
     "PRESETS",

--- a/hackagent/datasets/registry.py
+++ b/hackagent/datasets/registry.py
@@ -214,11 +214,13 @@ def _register_builtin_providers():
     """Register the built-in dataset providers."""
     from hackagent.datasets.providers.file import FileDatasetProvider
     from hackagent.datasets.providers.huggingface import HuggingFaceDatasetProvider
+    from hackagent.datasets.providers.url_json import UrlJsonDatasetProvider
 
     register_provider("huggingface", HuggingFaceDatasetProvider)
     register_provider("hf", HuggingFaceDatasetProvider)  # Alias
     register_provider("file", FileDatasetProvider)
     register_provider("local", FileDatasetProvider)  # Alias
+    register_provider("url_json", UrlJsonDatasetProvider)
 
 
 _register_builtin_providers()

--- a/hackagent/router/tracking/coordinator.py
+++ b/hackagent/router/tracking/coordinator.py
@@ -80,6 +80,7 @@ class TrackingCoordinator:
         logger: Optional[logging.Logger] = None,
         run_start_time: Optional[float] = None,
         goal_index_start: int = 0,
+        default_initial_metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize coordinator with pre-built trackers.
@@ -99,6 +100,9 @@ class TrackingCoordinator:
         self._goals: List[str] = []
         self._goal_indices: List[int] = []
         self._goal_index_start: int = int(goal_index_start)
+        self._default_initial_metadata: Dict[str, Any] = dict(
+            default_initial_metadata or {}
+        )
         self._run_start_time: float = (
             float(run_start_time)
             if isinstance(run_start_time, (int, float))
@@ -207,6 +211,7 @@ class TrackingCoordinator:
             logger=_logger,
             run_start_time=run_start_time,
             goal_index_start=goal_index_start,
+            default_initial_metadata=initial_metadata,
         )
 
         # Initialize goals if provided
@@ -258,7 +263,7 @@ class TrackingCoordinator:
         self,
         goals: List[str],
         initial_metadata: Optional[Dict[str, Any]] = None,
-        goal_index_start: int = 0,
+        goal_index_start: Optional[int] = None,
     ) -> None:
         """
         Create Result records for all goals upfront.
@@ -269,9 +274,14 @@ class TrackingCoordinator:
         Args:
             goals: List of goal strings
             initial_metadata: Optional metadata to attach to each goal result
-            goal_index_start: Starting index to assign to the first goal
+            goal_index_start: Optional starting index to assign to the first
+                goal. If omitted, preserves the coordinator's current offset.
         """
-        self._goal_index_start = int(goal_index_start)
+        if goal_index_start is None:
+            goal_index_start = self._goal_index_start
+        else:
+            self._goal_index_start = int(goal_index_start)
+            goal_index_start = self._goal_index_start
         self._goals = list(goals)
         self._goal_indices = [goal_index_start + i for i in range(len(goals))]
 
@@ -279,12 +289,40 @@ class TrackingCoordinator:
             self.logger.debug("Goal tracking disabled — skipping goal initialization")
             return
 
+        base_initial_metadata = dict(self._default_initial_metadata)
+        if initial_metadata:
+            base_initial_metadata.update(initial_metadata)
+        goal_metadata_by_index = base_initial_metadata.pop(
+            "_goal_metadata_by_index", {}
+        )
+        goal_metadata_by_goal = base_initial_metadata.pop("_goal_metadata_by_goal", {})
+        if not isinstance(goal_metadata_by_index, dict):
+            goal_metadata_by_index = {}
+        if not isinstance(goal_metadata_by_goal, dict):
+            goal_metadata_by_goal = {}
+
         for i, goal in enumerate(goals):
             goal_index = goal_index_start + i
+
+            per_goal_metadata: Dict[str, Any] = {}
+            goal_specific_meta = goal_metadata_by_index.get(
+                goal_index,
+                goal_metadata_by_index.get(str(goal_index)),
+            )
+            if not isinstance(goal_specific_meta, dict):
+                goal_specific_meta = goal_metadata_by_goal.get(goal)
+            if isinstance(goal_specific_meta, dict):
+                per_goal_metadata = dict(goal_specific_meta)
+
+            effective_initial_metadata = {
+                **base_initial_metadata,
+                **per_goal_metadata,
+            }
+
             self.goal_tracker.create_goal_result(
                 goal=goal,
                 goal_index=goal_index,
-                initial_metadata=initial_metadata or {},
+                initial_metadata=effective_initial_metadata,
             )
 
         self.logger.info(f"Initialized {len(goals)} goal results for tracking")

--- a/hackagent/server/dashboard/_result_detail_mixin.py
+++ b/hackagent/server/dashboard/_result_detail_mixin.py
@@ -158,6 +158,15 @@ class DashboardResultDetailMixin:
         if fc_graph_text and not fc_image:
             self._render_tfc_result_section(row, metadata)
 
+        # Dataset/provider extra fields (when available) are shown in a
+        # dedicated UX-friendly panel below the response sections.
+        if hasattr(self, "_render_extra_fields_panel") and hasattr(
+            self, "_extract_extra_fields_from_row"
+        ):
+            with contextlib.suppress(Exception):
+                if self._extract_extra_fields_from_row(row):
+                    self._render_extra_fields_panel(row)
+
         # Key-value detail table
         detail_fields = self._build_result_detail_fields(row)
         if detail_fields:
@@ -185,7 +194,7 @@ class DashboardResultDetailMixin:
         # Combine metrics + metadata for display
         combined: dict[str, object] = {}
         # Skip large binary data fields from the detail table
-        _skip_keys = {"image_data_url"}
+        _skip_keys = {"image_data_url", "extra_fields"}
         for src in (metadata, metrics):
             if isinstance(src, dict):
                 for k, v in src.items():

--- a/hackagent/server/dashboard/attack_cards/_shared.py
+++ b/hackagent/server/dashboard/attack_cards/_shared.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import contextlib
 import html
+import json
 import re
 
 from nicegui import ui
@@ -38,6 +39,67 @@ _ABBR_TO_TYPE = {
 
 class AttackCardSharedMixin:
     """Mixin providing shared attack-card helpers."""
+
+    @staticmethod
+    def _extract_extra_fields_from_row(row: dict) -> dict:
+        """Return normalized extra fields dict from a dashboard row metadata."""
+        metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+        if not metadata:
+            return {}
+
+        extra_fields = metadata.get("extra_fields")
+        if not isinstance(extra_fields, dict):
+            return {}
+
+        return {
+            str(k): v for k, v in extra_fields.items() if v not in (None, "", [], {})
+        }
+
+    @staticmethod
+    def _format_extra_field_value(value) -> str:
+        """Format extra field values for human-friendly dashboard display."""
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, indent=2, ensure_ascii=False, default=str)
+        return str(value)
+
+    def _render_extra_fields_panel(self, row: dict) -> None:
+        """Render the Extra Fields card in goal detail views."""
+        extra_fields = self._extract_extra_fields_from_row(row)
+        if not extra_fields:
+            return
+
+        with (
+            ui.card()
+            .tight()
+            .classes(
+                "w-full border border-cyan-200 bg-cyan-50 "
+                "dark:border-cyan-700 dark:bg-cyan-900/20"
+            )
+        ):
+            with ui.column().classes("w-full p-3 gap-2"):
+                with ui.row().classes("items-center gap-2"):
+                    ui.icon("data_object", color="primary").classes("text-sm")
+                    ui.label("EXTRA FIELDS").classes(
+                        "text-[10px] font-semibold tracking-widest text-grey-6 uppercase"
+                    )
+
+                for field_name, field_value in extra_fields.items():
+                    formatted = self._format_extra_field_value(field_value)
+                    with (
+                        ui.card()
+                        .tight()
+                        .classes(
+                            "w-full border border-cyan-100 bg-white "
+                            "dark:border-cyan-800 dark:bg-black/10"
+                        )
+                    ):
+                        with ui.column().classes("w-full p-2 gap-1"):
+                            ui.label(field_name).classes(
+                                "text-[11px] font-semibold text-cyan-8 dark:text-cyan-3"
+                            )
+                            ui.label(formatted).classes(
+                                "text-xs whitespace-pre-wrap break-words text-grey-8 dark:text-grey-2"
+                            ).style("overflow-wrap:anywhere;")
 
     @staticmethod
     def _build_judge_verdicts(
@@ -212,6 +274,9 @@ class AttackCardSharedMixin:
                 )
             ui.separator().classes("my-2")
             yield
+            if self._extract_extra_fields_from_row(row):
+                ui.separator().classes("my-2")
+                self._render_extra_fields_panel(row)
         else:
             with ui.card().tight().classes(f"w-full border-l-4 {border_color}"):
                 with ui.column().classes("w-full gap-2 p-3") as col:

--- a/tests/unit/attacks/test_orchestrator.py
+++ b/tests/unit/attacks/test_orchestrator.py
@@ -607,7 +607,10 @@ class TestAttackOrchestratorDatasetIntegration(unittest.TestCase):
     @patch("hackagent.attacks.orchestrator.AttackOrchestrator._load_goals_from_dataset")
     def test_prepare_attack_params_loads_from_dataset(self, mock_load):
         """Test that goals are loaded from dataset config when provided."""
-        mock_load.return_value = ["dataset_goal1", "dataset_goal2"]
+        mock_load.return_value = (
+            ["dataset_goal1", "dataset_goal2"],
+            {0: {"extra_fields": {"category": "cat-a"}}},
+        )
 
         attack_config = {
             "dataset": {
@@ -620,6 +623,8 @@ class TestAttackOrchestratorDatasetIntegration(unittest.TestCase):
 
         mock_load.assert_called_once_with(attack_config["dataset"])
         self.assertEqual(params["goals"], ["dataset_goal1", "dataset_goal2"])
+        self.assertIn("_goal_extra_fields_by_index", params)
+        self.assertIn("_goal_extra_fields_by_goal", params)
 
     @patch("hackagent.attacks.orchestrator.AttackOrchestrator._load_goals_from_dataset")
     def test_prepare_attack_params_prefers_direct_goals_over_dataset(self, mock_load):
@@ -710,10 +715,13 @@ class TestAttackOrchestratorDatasetIntegration(unittest.TestCase):
         mock_load_dataset.assert_not_called()
         self.assertEqual(params["goals"], ["intent_goal"])
 
-    @patch("hackagent.datasets.load_goals_from_config")
+    @patch("hackagent.datasets.load_goals_and_extra_fields_from_config")
     def test_load_goals_from_dataset_calls_registry(self, mock_load_goals):
         """Test that _load_goals_from_dataset calls the registry function."""
-        mock_load_goals.return_value = ["loaded_goal"]
+        mock_load_goals.return_value = (
+            ["loaded_goal"],
+            {0: {"extra_fields": {"category": "network"}}},
+        )
 
         dataset_config = {
             "provider": "huggingface",
@@ -721,12 +729,13 @@ class TestAttackOrchestratorDatasetIntegration(unittest.TestCase):
             "goal_field": "prompt",
         }
 
-        goals = self.orchestrator._load_goals_from_dataset(dataset_config)
+        goals, extras = self.orchestrator._load_goals_from_dataset(dataset_config)
 
         mock_load_goals.assert_called_once_with(dataset_config)
         self.assertEqual(goals, ["loaded_goal"])
+        self.assertIn(0, extras)
 
-    @patch("hackagent.datasets.load_goals_from_config")
+    @patch("hackagent.datasets.load_goals_and_extra_fields_from_config")
     def test_load_goals_from_dataset_handles_errors(self, mock_load_goals):
         """Test that dataset loading errors are wrapped in ValueError."""
         mock_load_goals.side_effect = Exception("Dataset not found")
@@ -738,10 +747,13 @@ class TestAttackOrchestratorDatasetIntegration(unittest.TestCase):
 
         self.assertIn("Failed to load goals", str(context.exception))
 
-    @patch("hackagent.datasets.load_goals_from_config")
+    @patch("hackagent.datasets.load_goals_and_extra_fields_from_config")
     def test_load_goals_from_dataset_with_preset(self, mock_load_goals):
         """Test loading goals using a preset configuration."""
-        mock_load_goals.return_value = ["agentharm_goal1", "agentharm_goal2"]
+        mock_load_goals.return_value = (
+            ["agentharm_goal1", "agentharm_goal2"],
+            {},
+        )
 
         dataset_config = {
             "preset": "agentharm",
@@ -749,10 +761,11 @@ class TestAttackOrchestratorDatasetIntegration(unittest.TestCase):
             "shuffle": True,
         }
 
-        goals = self.orchestrator._load_goals_from_dataset(dataset_config)
+        goals, extras = self.orchestrator._load_goals_from_dataset(dataset_config)
 
         mock_load_goals.assert_called_once_with(dataset_config)
         self.assertEqual(len(goals), 2)
+        self.assertEqual(extras, {})
 
 
 if __name__ == "__main__":

--- a/tests/unit/datasets/test_dataset_integrity.py
+++ b/tests/unit/datasets/test_dataset_integrity.py
@@ -206,7 +206,7 @@ class TestDatasetPresetInformation(unittest.TestCase):
         self.assertEqual(config["name"], "harmful")
         self.assertEqual(config["goal_field"], "prompt")
         self.assertEqual(config["split"], "test_public")
-        self.assertIn("176", config["description"])
+        self.assertIn("208", config["description"])
 
     def test_agentharm_benign_configuration(self):
         """Test AgentHarm benign preset is correctly configured."""
@@ -216,6 +216,16 @@ class TestDatasetPresetInformation(unittest.TestCase):
         self.assertEqual(config["path"], "ai-safety-institute/AgentHarm")
         self.assertEqual(config["name"], "harmless_benign")
         self.assertEqual(config["split"], "test_public_benign")
+        self.assertIn("208", config["description"])
+
+    def test_agenthazard_configuration(self):
+        """Test AgentHazard preset is correctly configured."""
+        config = get_preset("agenthazard")
+
+        self.assertEqual(config["provider"], "url_json")
+        self.assertIn("AgentHazard/data/dataset.json", config["url"])
+        self.assertEqual(config["goal_field"], "query")
+        self.assertIn("2653", config["description"])
 
     def test_strongreject_configuration(self):
         """Test StrongREJECT preset configuration."""

--- a/tests/unit/datasets/test_dataset_integrity.py
+++ b/tests/unit/datasets/test_dataset_integrity.py
@@ -75,7 +75,7 @@ class TestDatasetProfileIntegrity(unittest.TestCase):
 
     def test_all_presets_have_valid_providers(self):
         """Test that all presets use valid providers."""
-        valid_providers = {"huggingface", "hf", "file", "local"}
+        valid_providers = {"huggingface", "hf", "file", "local", "url_json"}
 
         for name, config in PRESETS.items():
             self.assertIn(
@@ -94,7 +94,7 @@ class TestDatasetDuplicates(unittest.TestCase):
     def _normalize_config(self, config: Dict[str, Any]) -> str:
         """Create a normalized string representation of config for comparison."""
         # Only compare fields that define the actual dataset
-        key_fields = ["provider", "path", "name", "goal_field", "split"]
+        key_fields = ["provider", "path", "name", "goal_field", "split", "url"]
         parts = []
         for field in key_fields:
             value = config.get(field, "")

--- a/tests/unit/datasets/test_huggingface_provider.py
+++ b/tests/unit/datasets/test_huggingface_provider.py
@@ -228,6 +228,107 @@ class TestHuggingFaceDatasetProvider(unittest.TestCase):
             call_kwargs = mock_datasets.load_dataset.call_args[1]
             self.assertEqual(call_kwargs["name"], "wmdp-bio")
 
+    def test_load_goals_with_extra_fields_return_dicts(self):
+        """Test returning dictionaries with extra metadata fields."""
+
+        with patch.dict("sys.modules", {"datasets": MagicMock()}):
+            import sys
+
+            mock_datasets = sys.modules["datasets"]
+
+            records = [
+                {
+                    "prompt": "Goal 1",
+                    "category": "network",
+                    "severity": "high",
+                },
+                {
+                    "prompt": "Goal 2",
+                    "category": "filesystem",
+                    "severity": "medium",
+                },
+            ]
+
+            mock_dataset = MagicMock()
+            mock_dataset.__iter__ = MagicMock(return_value=iter(records))
+            mock_dataset.__len__ = MagicMock(return_value=2)
+            mock_datasets.load_dataset.return_value = mock_dataset
+
+            from hackagent.datasets.providers.huggingface import (
+                HuggingFaceDatasetProvider,
+            )
+
+            provider = HuggingFaceDatasetProvider(
+                {
+                    "path": "test/dataset",
+                    "goal_field": "prompt",
+                    "extra_fields": ["category", "severity"],
+                }
+            )
+
+            goals = provider.load_goals(return_dicts=True)
+
+            self.assertEqual(
+                goals,
+                [
+                    {
+                        "goal": "Goal 1",
+                        "category": "network",
+                        "severity": "high",
+                    },
+                    {
+                        "goal": "Goal 2",
+                        "category": "filesystem",
+                        "severity": "medium",
+                    },
+                ],
+            )
+            self.assertEqual(
+                provider.get_extra_data(),
+                [
+                    {"category": "network", "severity": "high"},
+                    {"category": "filesystem", "severity": "medium"},
+                ],
+            )
+
+    def test_get_extra_data_resets_between_calls(self):
+        """Test that extra data is reset on each load_goals call."""
+
+        with patch.dict("sys.modules", {"datasets": MagicMock()}):
+            import sys
+
+            mock_datasets = sys.modules["datasets"]
+
+            records = [
+                {"prompt": "Goal 1", "category": "cat1"},
+                {"prompt": "Goal 2", "category": "cat2"},
+            ]
+            mock_dataset = MagicMock()
+            mock_dataset.__iter__ = MagicMock(side_effect=lambda: iter(records))
+            mock_dataset.__len__ = MagicMock(return_value=2)
+            mock_datasets.load_dataset.return_value = mock_dataset
+
+            from hackagent.datasets.providers.huggingface import (
+                HuggingFaceDatasetProvider,
+            )
+
+            provider = HuggingFaceDatasetProvider(
+                {
+                    "path": "test/dataset",
+                    "goal_field": "prompt",
+                    "extra_fields": ["category"],
+                }
+            )
+
+            provider.load_goals(limit=2)
+            self.assertEqual(
+                provider.get_extra_data(),
+                [{"category": "cat1"}, {"category": "cat2"}],
+            )
+
+            provider.load_goals(limit=1)
+            self.assertEqual(provider.get_extra_data(), [{"category": "cat1"}])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/datasets/test_presets.py
+++ b/tests/unit/datasets/test_presets.py
@@ -17,14 +17,30 @@ class TestPresets(unittest.TestCase):
 
     def test_all_presets_have_required_fields(self):
         """Test that all presets have required configuration fields."""
-        required_fields = {"provider", "path", "goal_field"}
-
         for name, config in PRESETS.items():
-            for field in required_fields:
+            # Base required fields for all presets
+            self.assertIn(
+                "provider", config, f"Preset '{name}' missing required field 'provider'"
+            )
+            self.assertIn(
+                "goal_field",
+                config,
+                f"Preset '{name}' missing required field 'goal_field'",
+            )
+
+            # Dynamic source field checking based on provider type
+            provider = config.get("provider")
+            if provider in ("huggingface", "hf", "file", "local"):
                 self.assertIn(
-                    field,
+                    "path",
                     config,
-                    f"Preset '{name}' missing required field '{field}'",
+                    f"Preset '{name}' missing required field 'path' for provider '{provider}'",
+                )
+            elif provider == "url_json":
+                self.assertIn(
+                    "url",
+                    config,
+                    f"Preset '{name}' missing required field 'url' for provider '{provider}'",
                 )
 
     def test_get_preset_returns_config(self):
@@ -35,7 +51,11 @@ class TestPresets(unittest.TestCase):
 
         self.assertIsInstance(config, dict)
         self.assertIn("provider", config)
-        self.assertIn("path", config)
+        # Check that it has either a path OR a url
+        has_source = "path" in config or "url" in config
+        self.assertTrue(
+            has_source, f"Preset '{preset_name}' must have either 'path' or 'url'"
+        )
 
     def test_get_preset_returns_copy(self):
         """Test that get_preset returns a copy, not the original."""

--- a/tests/unit/datasets/test_registry.py
+++ b/tests/unit/datasets/test_registry.py
@@ -14,6 +14,8 @@ from hackagent.datasets.registry import (
     _PROVIDERS,
     get_provider,
     load_goals,
+    load_goals_and_extra_fields,
+    load_goals_and_extra_fields_from_config,
     load_goals_from_config,
     register_provider,
 )
@@ -28,6 +30,7 @@ class TestProviderRegistry(unittest.TestCase):
         self.assertIn("hf", _PROVIDERS)  # Alias
         self.assertIn("file", _PROVIDERS)
         self.assertIn("local", _PROVIDERS)  # Alias
+        self.assertIn("url_json", _PROVIDERS)
 
     def test_register_custom_provider(self):
         """Test registering a custom provider."""
@@ -228,6 +231,69 @@ class TestLoadGoalsFromConfig(unittest.TestCase):
 
         mock_get_preset.assert_called_once_with("agentharm")
         self.assertEqual(goals, ["goal"])
+
+
+class TestLoadGoalsWithExtraFields(unittest.TestCase):
+    """Test extra-fields aware dataset loading helpers."""
+
+    @patch("hackagent.datasets.registry.get_provider")
+    @patch("hackagent.datasets.registry.get_preset")
+    def test_load_goals_and_extra_fields_from_preset(
+        self, mock_get_preset, mock_get_provider
+    ):
+        """Helper should return goals and normalized extra fields by index."""
+        mock_get_preset.return_value = {
+            "provider": "huggingface",
+            "path": "test/dataset",
+            "goal_field": "prompt",
+        }
+
+        mock_provider = MagicMock()
+        mock_provider.load_goals.return_value = ["g1", "g2"]
+        mock_provider.get_extra_data.return_value = [
+            {"category": "network", "severity": "high"},
+            {},
+        ]
+        mock_get_provider.return_value = mock_provider
+
+        goals, extras = load_goals_and_extra_fields(preset="agentharm", limit=2)
+
+        self.assertEqual(goals, ["g1", "g2"])
+        self.assertEqual(
+            extras,
+            {0: {"extra_fields": {"category": "network", "severity": "high"}}},
+        )
+
+    @patch("hackagent.datasets.registry.get_provider")
+    def test_load_goals_and_extra_fields_handles_missing_provider_method(
+        self, mock_get_provider
+    ):
+        """Providers without get_extra_data should still work and return empty map."""
+        mock_provider = MagicMock()
+        mock_provider.load_goals.return_value = ["g1"]
+        mock_provider.get_extra_data = None
+        mock_get_provider.return_value = mock_provider
+
+        goals, extras = load_goals_and_extra_fields(
+            provider="file",
+            path="/tmp/goals.json",
+            goal_field="goal",
+        )
+
+        self.assertEqual(goals, ["g1"])
+        self.assertEqual(extras, {})
+
+    @patch("hackagent.datasets.registry.load_goals_and_extra_fields")
+    def test_load_goals_and_extra_fields_from_config_wrapper(self, mock_loader):
+        """Config wrapper should delegate to main helper unchanged."""
+        mock_loader.return_value = (["goal"], {0: {"extra_fields": {"k": "v"}}})
+
+        config = {"preset": "agenthazard", "limit": 1}
+        goals, extras = load_goals_and_extra_fields_from_config(config)
+
+        mock_loader.assert_called_once_with(**config)
+        self.assertEqual(goals, ["goal"])
+        self.assertEqual(extras, {0: {"extra_fields": {"k": "v"}}})
 
 
 if __name__ == "__main__":

--- a/tests/unit/datasets/test_url_json_provider.py
+++ b/tests/unit/datasets/test_url_json_provider.py
@@ -1,0 +1,234 @@
+# Copyright 2026 - AI4I. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for URL JSON dataset provider."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from hackagent.datasets.providers.url_json import UrlJsonDatasetProvider
+
+
+class _MockHTTPResponse:
+    """Simple HTTP response context manager for urllib mocks."""
+
+    def __init__(self, payload: str):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._payload.encode("utf-8")
+
+
+class TestUrlJsonDatasetProvider(unittest.TestCase):
+    """Test UrlJsonDatasetProvider functionality."""
+
+    def test_init_requires_url(self):
+        """Test that initialization fails when url is missing."""
+        with self.assertRaises(ValueError) as context:
+            UrlJsonDatasetProvider({})
+
+        self.assertIn("url", str(context.exception).lower())
+
+    def test_load_goals_from_url_and_cache_dataset(self):
+        """Test loading goals from URL and reusing cached dataset."""
+        payload = json.dumps(
+            [
+                {"query": "Goal 1"},
+                {"query": "Goal 2"},
+            ]
+        )
+
+        with patch(
+            "hackagent.datasets.providers.url_json.urllib.request.urlopen",
+            return_value=_MockHTTPResponse(payload),
+        ) as mock_urlopen:
+            provider = UrlJsonDatasetProvider(
+                {
+                    "url": "https://example.com/dataset.json",
+                    "goal_field": "query",
+                }
+            )
+
+            first = provider.load_goals(limit=1)
+            second = provider.load_goals()
+
+            self.assertEqual(first, ["Goal 1"])
+            self.assertEqual(second, ["Goal 1", "Goal 2"])
+            mock_urlopen.assert_called_once()
+
+            metadata = provider.get_metadata()
+            self.assertEqual(metadata["provider"], "url_json")
+            self.assertEqual(metadata["total_samples"], 2)
+            self.assertEqual(metadata["goals_loaded"], 2)
+
+    def test_load_goals_supports_wrapped_json_payload(self):
+        """Test loading from JSON objects wrapped under common list keys."""
+        payload = json.dumps(
+            {
+                "records": [
+                    {"query": "Record goal 1"},
+                    {"query": "Record goal 2"},
+                ]
+            }
+        )
+
+        with patch(
+            "hackagent.datasets.providers.url_json.urllib.request.urlopen",
+            return_value=_MockHTTPResponse(payload),
+        ):
+            provider = UrlJsonDatasetProvider(
+                {
+                    "url": "https://example.com/wrapped.json",
+                    "goal_field": "query",
+                }
+            )
+
+            goals = provider.load_goals()
+            self.assertEqual(goals, ["Record goal 1", "Record goal 2"])
+
+    def test_load_goals_with_extra_fields_and_return_dicts(self):
+        """Test returning goals as dictionaries with additional metadata."""
+        payload = json.dumps(
+            [
+                {
+                    "query": "Goal 1",
+                    "category": "credential-exposure",
+                    "jailbreak_method": "role-play",
+                },
+                {
+                    "query": "Goal 2",
+                    "category": "tool-misuse",
+                    "jailbreak_method": "obfuscation",
+                },
+            ]
+        )
+
+        with patch(
+            "hackagent.datasets.providers.url_json.urllib.request.urlopen",
+            return_value=_MockHTTPResponse(payload),
+        ):
+            provider = UrlJsonDatasetProvider(
+                {
+                    "url": "https://example.com/agenthazard.json",
+                    "goal_field": "query",
+                    "extra_fields": ["category", "jailbreak_method"],
+                }
+            )
+
+            goals = provider.load_goals(return_dicts=True)
+
+            self.assertEqual(
+                goals,
+                [
+                    {
+                        "goal": "Goal 1",
+                        "category": "credential-exposure",
+                        "jailbreak_method": "role-play",
+                    },
+                    {
+                        "goal": "Goal 2",
+                        "category": "tool-misuse",
+                        "jailbreak_method": "obfuscation",
+                    },
+                ],
+            )
+            self.assertEqual(
+                provider.get_extra_data(),
+                [
+                    {
+                        "category": "credential-exposure",
+                        "jailbreak_method": "role-play",
+                    },
+                    {
+                        "category": "tool-misuse",
+                        "jailbreak_method": "obfuscation",
+                    },
+                ],
+            )
+
+    def test_load_goals_shuffle_uses_seed_and_shuffle(self):
+        """Test shuffle path uses random.seed and random.shuffle."""
+        payload = json.dumps(
+            [
+                {"query": "Goal A"},
+                {"query": "Goal B"},
+            ]
+        )
+
+        with (
+            patch(
+                "hackagent.datasets.providers.url_json.urllib.request.urlopen",
+                return_value=_MockHTTPResponse(payload),
+            ),
+            patch("hackagent.datasets.providers.url_json.random.seed") as mock_seed,
+            patch(
+                "hackagent.datasets.providers.url_json.random.shuffle"
+            ) as mock_shuffle,
+        ):
+            provider = UrlJsonDatasetProvider(
+                {
+                    "url": "https://example.com/shuffle.json",
+                    "goal_field": "query",
+                }
+            )
+
+            provider.load_goals(shuffle=True, seed=123)
+
+            mock_seed.assert_called_once_with(123)
+            mock_shuffle.assert_called_once()
+
+    def test_load_goals_skips_invalid_records_with_warning(self):
+        """Test records without goal fields are skipped and warned."""
+        payload = json.dumps(
+            [
+                {"query": "Goal 1"},
+                {"no_goal": "skip me"},
+            ]
+        )
+
+        with patch(
+            "hackagent.datasets.providers.url_json.urllib.request.urlopen",
+            return_value=_MockHTTPResponse(payload),
+        ):
+            provider = UrlJsonDatasetProvider(
+                {
+                    "url": "https://example.com/invalid.json",
+                    "goal_field": "query",
+                }
+            )
+
+            with patch.object(provider.logger, "warning") as mock_warning:
+                goals = provider.load_goals()
+
+            self.assertEqual(goals, ["Goal 1"])
+            mock_warning.assert_called_once()
+
+    def test_load_goals_raises_if_download_fails(self):
+        """Test provider re-raises errors when URL fetch fails."""
+        with patch(
+            "hackagent.datasets.providers.url_json.urllib.request.urlopen",
+            side_effect=RuntimeError("network error"),
+        ):
+            provider = UrlJsonDatasetProvider(
+                {
+                    "url": "https://example.com/fail.json",
+                    "goal_field": "query",
+                }
+            )
+
+            with patch.object(provider.logger, "error") as mock_error:
+                with self.assertRaises(RuntimeError):
+                    provider.load_goals()
+
+            mock_error.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/router/tracking/test_coordinator.py
+++ b/tests/unit/router/tracking/test_coordinator.py
@@ -100,6 +100,123 @@ class TestTrackingCoordinatorDeferredInit(unittest.TestCase):
         self.assertEqual(fake_goal_tracker.created[1]["goal"], "g2")
         self.assertEqual(fake_goal_tracker.created[1]["goal_index"], 6)
 
+    def test_initialize_goals_without_explicit_offset_preserves_existing_start(self):
+        """When omitted, goal_index_start should reuse coordinator offset."""
+        fake_goal_tracker = _FakeInitGoalTracker()
+        coordinator = TrackingCoordinator(
+            step_tracker=MagicMock(),
+            goal_tracker=fake_goal_tracker,
+            logger=MagicMock(),
+            goal_index_start=11,
+            default_initial_metadata={
+                "_goal_metadata_by_index": {
+                    11: {"extra_fields": {"category": "cat-a"}},
+                    12: {"extra_fields": {"category": "cat-b"}},
+                }
+            },
+        )
+
+        coordinator.initialize_goals(
+            goals=["g1", "g2"],
+            initial_metadata={"attack_type": "h4rm3l"},
+        )
+
+        self.assertEqual(len(fake_goal_tracker.created), 2)
+        self.assertEqual(fake_goal_tracker.created[0]["goal_index"], 11)
+        self.assertEqual(fake_goal_tracker.created[1]["goal_index"], 12)
+
+        first_meta = fake_goal_tracker.created[0]["initial_metadata"]
+        second_meta = fake_goal_tracker.created[1]["initial_metadata"]
+        self.assertEqual(first_meta["extra_fields"], {"category": "cat-a"})
+        self.assertEqual(second_meta["extra_fields"], {"category": "cat-b"})
+
+    def test_initialize_goals_applies_goal_specific_metadata(self):
+        """Per-goal metadata maps should merge correctly into initial metadata."""
+        fake_goal_tracker = _FakeInitGoalTracker()
+        coordinator = TrackingCoordinator(
+            step_tracker=MagicMock(),
+            goal_tracker=fake_goal_tracker,
+            logger=MagicMock(),
+            goal_index_start=5,
+        )
+
+        coordinator.initialize_goals(
+            goals=["g1", "g2"],
+            initial_metadata={
+                "attack_type": "baseline",
+                "_goal_metadata_by_index": {
+                    5: {"extra_fields": {"category": "cat-a"}},
+                },
+                "_goal_metadata_by_goal": {
+                    "g2": {"extra_fields": {"category": "cat-b"}},
+                },
+            },
+            goal_index_start=5,
+        )
+
+        self.assertEqual(len(fake_goal_tracker.created), 2)
+
+        first_meta = fake_goal_tracker.created[0]["initial_metadata"]
+        second_meta = fake_goal_tracker.created[1]["initial_metadata"]
+
+        self.assertEqual(first_meta["attack_type"], "baseline")
+        self.assertEqual(
+            first_meta["extra_fields"],
+            {"category": "cat-a"},
+        )
+
+        self.assertEqual(second_meta["attack_type"], "baseline")
+        self.assertEqual(
+            second_meta["extra_fields"],
+            {"category": "cat-b"},
+        )
+
+    def test_deferred_initialize_uses_default_initial_metadata_maps(self):
+        """Default metadata passed at construction must survive deferred init."""
+        fake_goal_tracker = _FakeInitGoalTracker()
+        coordinator = TrackingCoordinator(
+            step_tracker=MagicMock(),
+            goal_tracker=fake_goal_tracker,
+            logger=MagicMock(),
+            goal_index_start=10,
+            default_initial_metadata={
+                "attack_type": "h4rm3l",
+                "_goal_metadata_by_index": {
+                    10: {"extra_fields": {"category": "cat-a"}},
+                },
+                "_goal_metadata_by_goal": {
+                    "g2": {"extra_fields": {"category": "cat-b"}},
+                },
+            },
+        )
+
+        coordinator.initialize_goals_from_pipeline_data(
+            pipeline_data=[
+                {"goal": "g1", "elapsed_s": 0.1},
+                {"goal": "g2", "elapsed_s": 0.2},
+            ],
+            initial_metadata={"batch_size": 8},
+        )
+
+        self.assertEqual(len(fake_goal_tracker.created), 2)
+
+        first_meta = fake_goal_tracker.created[0]["initial_metadata"]
+        second_meta = fake_goal_tracker.created[1]["initial_metadata"]
+
+        self.assertEqual(first_meta["attack_type"], "h4rm3l")
+        self.assertEqual(first_meta["batch_size"], 8)
+        self.assertEqual(
+            first_meta["extra_fields"],
+            {"category": "cat-a"},
+        )
+
+        self.assertEqual(second_meta["attack_type"], "h4rm3l")
+        self.assertEqual(second_meta["batch_size"], 8)
+        self.assertEqual(
+            second_meta["extra_fields"],
+            {"category": "cat-b"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


## Summary
This PR introduces a new dataset provider (`UrlJsonDatasetProvider`) capable of downloading and loading JSON datasets directly into RAM from a remote URL, bypassing the need for local storage. 
Furthermore, it adds the [AgentHazard](https://yunhao-feng.github.io/AgentHazard/data/dataset.json) dataset available as a json while also fetching some extra fields beside the goal field, and it enriches the [AgentHarm](https://huggingface.co/datasets/ai-safety-institute/AgentHarm/viewer/harmful) dataset with extra fields. These extra fields are useful for implementing tool-use attacks based on those datasets and are detailed below.

Specifically, this PR enhances the dataset extraction logic across multiple providers to support harvesting arbitrary metadata (`extra_fields`) alongside the primary goals. This was implemented with strict backward compatibility: `load_goals()` continues to return `List[str]` by default, ensuring no existing orchestration scripts break, while allowing new scripts to access the metadata on demand.

This now allows to load additional fields besides the goal field. In particular, in presets.py, the additional fields for AgentHazard are

```
"extra_fields": [
            "category",
            "decomposed_query",
            "jailbreak_method",
],
```

whereas the ones for AgentHarm are

```
"extra_fields": [
            "detailed_prompt",
            "hint_included",
            "target_functions",
            "grading_function",
],

```

and both HuggingFaceDatasetProvider and the new UrlJsonDatasetProvider now support the fetch of these fields. These fields can be used for implementing the attacks supporting [AgentHazard](https://yunhao-feng.github.io/AgentHazard/) and [AgentHarm](https://ukgovernmentbeis.github.io/inspect_evals/evals/agentharm/index.html).

## Key Changes

### 1. New Provider: `UrlJsonDatasetProvider`
* **File:** `hackagent/datasets/providers/url_json.py`
* Created a lightweight provider using Python's native `urllib` to fetch JSON data from the web.
* Automatically handles standard JSON arrays and nested structures (e.g., `{"data": [...]}`).
* Fully supports `limit`, `shuffle`, and `seed` parameters.

### 2. Backward-Compatible Metadata Extraction
* **Files:** `huggingface.py`, `url_json.py`
* Introduced the `extra_fields` configuration parameter to extract supplementary data (e.g., `target_functions`, `risk_category`) during the main loop.
* **Non-breaking:** `load_goals()` defaults to returning pure strings. Metadata is silently cached in parallel.
* **New API:** Added `get_extra_data()` to fetch the cached metadata array (indices match the goal strings perfectly).
* **Direct Mode:** Added a `return_dicts=True` kwarg to `load_goals` for scripts that want the combined dictionary upfront.

### 3. Registry & Configuration Updates
* **Files:** `registry.py`, `providers/__init__.py`, `presets.py`
* Registered `url_json` as a core provider.
* Added the `agenthazard` preset, configured to pull from `yunhao-feng.github.io/AgentHazard`.
* Enriched the existing `agentharm` preset to explicitly extract `target_functions` and `grading_function`.

### 4. Test Suite Adaptations
* **Files:** `test_dataset_integrity.py`, `test_presets.py`
* Updated the test suite's strict assertions to account for the new provider paradigm. 
* Tests now dynamically validate that presets must contain either a `path` (for local/HF datasets) **OR** a `url` (for the new `url_json` provider).
* Added `url_json` to the internal set of globally valid providers to fix assertion failures in profile integrity tests.

## Testing Performed
- Verified `HuggingFaceDatasetProvider` still successfully loads `List[str]`.
- Verified `UrlJsonDatasetProvider` successfully fetches remote JSON and parses it into RAM.
- Verified `shuffle` and `seed` function correctly on the URL-loaded dataset.