### PR TITLE
chore: add Google Analytics (gtag) tracking

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -64,6 +64,10 @@ const config: Config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        gtag: {
+          trackingID: 'G-2P6K2HWVEE',
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
## What
Add the Google Analytics 4 tag (`G-2P6K2HWVEE`) using the framework-idiomatic approach.

## How
- **Next.js (landing & webapp):** `@next/third-parties` `GoogleAnalytics` component mounted in the root layout — loads `gtag.js` with the correct App Router strategy and handles SPA route-change pageviews automatically.
- **Docs (Docusaurus):** the built-in `gtag` option of `preset-classic` (`trackingID: G-2P6K2HWVEE`, `anonymizeIP: true`). No extra dependency.

## Notes
- Docusaurus only injects gtag in a production build (`docusaurus build`/`serve`), not in `docusaurus start` dev mode — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)