### PR TITLE
fix: prevent Select crash from stale None cached values in Attacks tab

### DIFF
--- a/hackagent/cli/tui/views/attacks.py
+++ b/hackagent/cli/tui/views/attacks.py
@@ -667,7 +667,9 @@ class AttacksTab(Container):
                 continue
             value = flat_values[cfg_field.key]
             if isinstance(widget, Select):
-                widget.value = value
+                # None isn't a legal Select value (only the NoSelection sentinel is) — skip and keep its constructed default.
+                if value is not None:
+                    widget.value = value
             elif isinstance(widget, Switch):
                 widget.value = bool(value)
             elif isinstance(widget, TextArea):
@@ -912,7 +914,8 @@ class AttacksTab(Container):
             if isinstance(widget, Select):
                 raw = widget.value
                 if isinstance(raw, NoSelection):
-                    raw = None
+                    # Fall back to the field's default rather than caching a bare None.
+                    raw = cfg_field.default
             elif isinstance(widget, Switch):
                 raw = widget.value
             elif isinstance(widget, TextArea):


### PR DESCRIPTION
Caching a strategy's config while a Select field briefly reads as NoSelection (e.g. during the startup h4rm3l/TAP/PAIR auto-focus sequence) stored a bare None, which isn't a legal Select value. Reapplying that cache later crashed with InvalidSelectValueError. Fall back to the field's default when caching, and skip reapplying None onto Select widgets.