### PR TITLE
feat(cli): add datasets list/show/sample commands

### DIFF
--- a/docs/docs/cli/datasets.md
+++ b/docs/docs/cli/datasets.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 6
+---
+
+# Datasets
+
+The `hackagent datasets` command lets you discover built-in dataset presets and preview sample goals before running an evaluation.
+
+## Commands
+
+### List Presets
+
+```bash
+hackagent datasets list
+```
+
+Filter by provider or search text:
+
+```bash
+hackagent datasets list --provider huggingface
+hackagent datasets list --query jailbreak
+```
+
+Machine-readable output:
+
+```bash
+hackagent datasets list --json
+```
+
+### Show Preset Details
+
+```bash
+hackagent datasets show strongreject
+hackagent datasets show agentharm --json
+```
+
+### Sample Goals
+
+Load a few goals from a preset (downloads/fetches the underlying dataset as needed):
+
+```bash
+hackagent datasets sample strongreject --limit 5
+hackagent datasets sample agentharm --limit 3 --shuffle --seed 42
+hackagent datasets sample strongreject --limit 5 --json
+```
+
+## Use With Evals
+
+Once you pick a preset, pass it to `hackagent eval`:
+
+```bash
+hackagent eval advprefix \
+  --agent-name "my-agent" \
+  --dataset strongreject \
+  --limit 25
+```

--- a/docs/docs/cli/overview.md
+++ b/docs/docs/cli/overview.md
@@ -20,6 +20,7 @@ For installation instructions, see the [Installation Guide](../getting-started/i
 | `hackagent eval <attack_name>` | Execute one specific attack strategy | [Eval](./attack.mdx) |
 | `hackagent examples ollama` | Run built-in Ollama demo | [Quick Start (TUI tab)](../getting-started/quick-start.mdx) |
 | `hackagent results` | View and manage results | [Results](./results.md) |
+| `hackagent datasets` | Browse and sample dataset presets | [Datasets](./datasets.md) |
 | `hackagent version` | Show version info | - |
 
 ## Quick Examples

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -157,6 +157,7 @@ const sidebars: SidebarsConfig = {
         'cli/config',
         'cli/attack',
         'cli/results',
+        'cli/datasets',
       ],
     },
     {

--- a/hackagent/cli/commands/datasets.py
+++ b/hackagent/cli/commands/datasets.py
@@ -1,0 +1,236 @@
+# Copyright 2026 - AI4I. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Datasets Commands
+
+Browse built-in dataset presets and sample goals for evals.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from hackagent.cli.utils import display_info, handle_errors
+from hackagent.datasets.presets import PRESETS, get_preset
+
+console = Console()
+
+# Fields that are metadata for display, not raw runtime config only.
+_DISPLAY_SKIP_KEYS = frozenset({"description"})
+
+
+@click.group()
+def datasets():
+    """📚 Browse and sample dataset presets"""
+    pass
+
+
+def _source_for_preset(config: Dict[str, Any]) -> str:
+    """Return a short source locator for a preset config."""
+    if "path" in config and config["path"]:
+        return str(config["path"])
+    if "url" in config and config["url"]:
+        return str(config["url"])
+    return "—"
+
+
+def _filter_presets(
+    provider: Optional[str] = None,
+    query: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Return presets filtered by optional provider and name/description query."""
+    query_lower = (query or "").strip().lower()
+    provider_lower = (provider or "").strip().lower()
+
+    filtered: Dict[str, Dict[str, Any]] = {}
+    for name, config in sorted(PRESETS.items()):
+        if provider_lower and str(config.get("provider", "")).lower() != provider_lower:
+            continue
+        if query_lower:
+            description = str(config.get("description", "")).lower()
+            if query_lower not in name.lower() and query_lower not in description:
+                continue
+        filtered[name] = config
+    return filtered
+
+
+@datasets.command("list")
+@click.option(
+    "--provider",
+    type=click.Choice(
+        ["huggingface", "hf", "file", "local", "url_json"],
+        case_sensitive=False,
+    ),
+    help="Filter by provider type",
+)
+@click.option(
+    "--query",
+    "-q",
+    help="Filter by name or description substring",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON",
+)
+@handle_errors
+def list_cmd(provider: Optional[str], query: Optional[str], as_json: bool):
+    """List available dataset presets"""
+
+    filtered = _filter_presets(provider=provider, query=query)
+    if not filtered:
+        display_info("No dataset presets matched the given filters.")
+        return
+
+    if as_json:
+        payload = [
+            {
+                "name": name,
+                "provider": config.get("provider"),
+                "description": config.get("description", ""),
+                "source": _source_for_preset(config),
+                "goal_field": config.get("goal_field"),
+            }
+            for name, config in filtered.items()
+        ]
+        console.print_json(data=payload)
+        return
+
+    table = Table(
+        title=f"Dataset Presets ({len(filtered)})",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Provider", style="green")
+    table.add_column("Source", style="dim", overflow="fold")
+    table.add_column("Description", overflow="fold")
+
+    for name, config in filtered.items():
+        table.add_row(
+            name,
+            str(config.get("provider", "—")),
+            _source_for_preset(config),
+            str(config.get("description", "No description")),
+        )
+
+    console.print(table)
+    console.print(
+        "\n[dim]Tip:[/dim] use [cyan]hackagent datasets show <name>[/cyan] "
+        "or [cyan]hackagent datasets sample <name>[/cyan]"
+    )
+
+
+@datasets.command("show")
+@click.argument("preset")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON",
+)
+@handle_errors
+def show_cmd(preset: str, as_json: bool):
+    """Show details for a dataset preset"""
+
+    config = get_preset(preset)
+
+    if as_json:
+        console.print_json(data={"name": preset.lower().replace("-", "_"), **config})
+        return
+
+    table = Table(
+        title=f"Dataset Preset: {preset}",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Property", style="cyan")
+    table.add_column("Value", style="green", overflow="fold")
+
+    description = config.get("description", "No description")
+    table.add_row("Description", str(description))
+
+    for key, value in config.items():
+        if key in _DISPLAY_SKIP_KEYS:
+            continue
+        if isinstance(value, (list, dict)):
+            rendered = json.dumps(value, indent=2)
+        else:
+            rendered = str(value)
+        table.add_row(key, rendered)
+
+    console.print(table)
+    console.print(
+        f"\n[dim]Sample goals:[/dim] [cyan]hackagent datasets sample {preset} --limit 5[/cyan]"
+    )
+
+
+@datasets.command("sample")
+@click.argument("preset")
+@click.option("--limit", default=5, show_default=True, help="Number of goals to load")
+@click.option("--shuffle", is_flag=True, help="Shuffle before selecting")
+@click.option("--seed", type=int, help="Random seed used with --shuffle")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON",
+)
+@handle_errors
+def sample_cmd(
+    preset: str,
+    limit: int,
+    shuffle: bool,
+    seed: Optional[int],
+    as_json: bool,
+):
+    """Load and print sample goals from a dataset preset"""
+
+    if limit < 1:
+        raise click.ClickException("--limit must be at least 1")
+
+    # Validate preset early for a clear error before network I/O.
+    get_preset(preset)
+
+    from hackagent.datasets import load_goals
+
+    with console.status(f"[bold green]Loading up to {limit} goals from '{preset}'..."):
+        goals: List[str] = load_goals(
+            preset=preset,
+            limit=limit,
+            shuffle=shuffle,
+            seed=seed,
+        )
+
+    if not goals:
+        display_info(f"No goals returned for preset '{preset}'.")
+        return
+
+    if as_json:
+        console.print_json(
+            data={
+                "preset": preset,
+                "count": len(goals),
+                "goals": goals,
+            }
+        )
+        return
+
+    console.print(
+        f"[bold cyan]Sample goals from '{preset}'[/bold cyan] "
+        f"[dim]({len(goals)} shown)[/dim]\n"
+    )
+    for index, goal in enumerate(goals, start=1):
+        console.print(f"[cyan]{index}.[/cyan] {goal}")
+
+    console.print(
+        f"\n[dim]Use in evals:[/dim] "
+        f"[cyan]hackagent eval advprefix --dataset {preset} --limit {limit} ...[/cyan]"
+    )

--- a/hackagent/cli/main.py
+++ b/hackagent/cli/main.py
@@ -22,6 +22,7 @@ from hackagent.cli.commands import (
     claude as claude_cmd,
     codex as codex_cmd,
     config,
+    datasets as datasets_cmd,
     examples,
     results,
     scan as scan_cmd,
@@ -575,6 +576,7 @@ cli.add_command(attack.eval_cmd)
 cli.add_command(scan_cmd.scan)
 cli.add_command(claude_cmd.claude)
 cli.add_command(codex_cmd.codex)
+cli.add_command(datasets_cmd.datasets)
 cli.add_command(examples.examples)
 cli.add_command(results.results)
 cli.add_command(web_cmd.web)

--- a/tests/unit/cli/test_datasets_command.py
+++ b/tests/unit/cli/test_datasets_command.py
@@ -1,0 +1,133 @@
+# Copyright 2026 - AI4I. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the `hackagent datasets` CLI commands."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from hackagent.cli.commands.datasets import datasets
+from hackagent.cli.main import cli
+from hackagent.datasets.presets import PRESETS
+
+
+class TestDatasetsCommand(unittest.TestCase):
+    """Test browse/sample behavior for the datasets CLI group."""
+
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+        self.known_preset = next(iter(PRESETS.keys()))
+
+    def test_datasets_registered_on_main_cli(self):
+        result = self.runner.invoke(cli, ["datasets", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("list", result.output)
+        self.assertIn("show", result.output)
+        self.assertIn("sample", result.output)
+
+    def test_list_shows_presets(self):
+        result = self.runner.invoke(datasets, ["list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(self.known_preset, result.output)
+        self.assertIn("Dataset Presets", result.output)
+
+    def test_list_json_output(self):
+        result = self.runner.invoke(datasets, ["list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertIsInstance(payload, list)
+        self.assertGreater(len(payload), 0)
+        self.assertIn("name", payload[0])
+        self.assertIn("provider", payload[0])
+        names = {item["name"] for item in payload}
+        self.assertIn(self.known_preset, names)
+
+    def test_list_filter_by_query(self):
+        result = self.runner.invoke(
+            datasets, ["list", "--query", self.known_preset, "--json"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertTrue(all(self.known_preset in item["name"] for item in payload))
+
+    def test_list_filter_no_matches(self):
+        result = self.runner.invoke(
+            datasets, ["list", "--query", "definitely-not-a-real-preset-xyz"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No dataset presets matched", result.output)
+
+    def test_show_preset_details(self):
+        result = self.runner.invoke(datasets, ["show", self.known_preset])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(self.known_preset, result.output)
+        self.assertIn("provider", result.output)
+        self.assertIn("goal_field", result.output)
+
+    def test_show_json_output(self):
+        result = self.runner.invoke(datasets, ["show", self.known_preset, "--json"])
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertIn("provider", payload)
+        self.assertIn("goal_field", payload)
+
+    def test_show_unknown_preset_fails(self):
+        result = self.runner.invoke(datasets, ["show", "not-a-real-preset"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Unknown preset", result.output)
+
+    def test_sample_loads_goals(self):
+        fake_goals = ["goal one", "goal two"]
+        with patch(
+            "hackagent.datasets.load_goals",
+            return_value=fake_goals,
+        ) as mock_load:
+            result = self.runner.invoke(
+                datasets, ["sample", self.known_preset, "--limit", "2"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("goal one", result.output)
+        self.assertIn("goal two", result.output)
+        mock_load.assert_called_once_with(
+            preset=self.known_preset,
+            limit=2,
+            shuffle=False,
+            seed=None,
+        )
+
+    def test_sample_json_output(self):
+        fake_goals = ["alpha", "beta"]
+        with patch("hackagent.datasets.load_goals", return_value=fake_goals):
+            result = self.runner.invoke(
+                datasets,
+                ["sample", self.known_preset, "--limit", "2", "--json"],
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["preset"], self.known_preset)
+        self.assertEqual(payload["count"], 2)
+        self.assertEqual(payload["goals"], fake_goals)
+
+    def test_sample_invalid_limit(self):
+        result = self.runner.invoke(
+            datasets, ["sample", self.known_preset, "--limit", "0"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--limit must be at least 1", result.output)
+
+    def test_sample_unknown_preset_fails_before_load(self):
+        with patch("hackagent.datasets.load_goals") as mock_load:
+            result = self.runner.invoke(datasets, ["sample", "not-a-real-preset"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Unknown preset", result.output)
+        mock_load.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `hackagent datasets` CLI group with `list`, `show`, and `sample` so users can discover built-in dataset presets without reading source/docs
- Support filters (`--provider`, `--query`) and `--json` output for scripting/CI
- Document the new commands and cover them with unit tests (12 passed)

## Test plan
- [x] `ruff check` / `ruff format --check` on changed Python files
- [x] `pytest tests/unit/cli/test_datasets_command.py` (12 passed)
- [x] Smoke: `hackagent datasets list`
- [x] Smoke: `hackagent datasets show strongreject`
- [x] Smoke: unknown preset fails clearly for `sample`
- [x] Optional: `hackagent datasets sample strongreject --limit 3` with network/HF access