### PR TITLE
fix(tracking): restore trace persistence after merge

### DIFF
--- a/hackagent/router/tracking/tracker.py
+++ b/hackagent/router/tracking/tracker.py
@@ -495,7 +495,6 @@ class Tracker:
                 content=sanitized_content,
                 elapsed_s=trace_record["elapsed_s"],
             )
-            self._record_failure(f"Goal {ctx.goal_index}: create trace", e)
 
             # Send to backend if enabled and we have a result_id
             if not self.is_enabled or not ctx.result_id:
@@ -523,6 +522,7 @@ class Tracker:
                     f"Exception creating trace for goal {ctx.goal_index}: {e}",
                     exc_info=True,
                 )
+                self._record_failure(f"Goal {ctx.goal_index}: create trace", e)
 
             return None
 


### PR DESCRIPTION
## Problem

`main` currently raises `UnboundLocalError` for every tracking trace because `_add_trace()` references the exception variable `e` on the successful path.

This breaks normal trace recording before the backend-enabled check and causes five existing unit tests to fail.

## Root cause

PR #518 correctly added `_record_failure(...)` to the `except` block around backend trace persistence. When #518 was merged alongside #519's trace-lock changes, the call was misplaced immediately after `_emit(...)`, outside the exception handler.

## Implementation

Move `_record_failure(...)` back into the backend persistence `except` block. Successful local and persisted traces no longer reference an undefined exception, while real persistence failures continue to be recorded on the parent run.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check hackagent/router/tracking/tracker.py`
- `uv run pytest -q tests/unit/attacks/test_error_propagation.py tests/unit/attacks/test_evaluation_updates.py tests/unit/router/tracking/test_goal_tracker_concurrency.py` — 28 passed
- `uv run pytest tests/ -q` — 2,733 passed, 135 skipped, 177 subtests passed

## Risk

Low. This is a one-line relocation that restores the behavior already reviewed and tested in #518. It does not change public APIs, schemas, or successful trace ordering.

## Backward compatibility

Fully backward compatible.

## Future improvements

Because the regression was introduced while merging two independently green PRs, running the unit-test gate against the final merge result would catch this class of conflict-resolution error before `main` advances.
