### PR TITLE
Add flipattack, cipherchat, bon, pap, fc jailbreak framing techniques

### DIFF
--- a/hackagent/attacks/techniques/rag/attack.py
+++ b/hackagent/attacks/techniques/rag/attack.py
@@ -1000,7 +1000,10 @@ class RagAttack(BaseAttack):
         )
 
         jailbreak_framer = build_jailbreak_framer(
-            poisoning_config.get("jailbreak"), self.logger
+            poisoning_config.get("jailbreak"),
+            self.logger,
+            attacker_router=self.attacker_router,
+            attacker_reg_key=self.attacker_reg_key,
         )
         payload_variant_index = 0
 

--- a/hackagent/attacks/techniques/rag/jailbreak.py
+++ b/hackagent/attacks/techniques/rag/jailbreak.py
@@ -14,12 +14,19 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from hackagent.attacks.generator import AttackTemplates
+from hackagent.attacks.shared.response_utils import extract_response_content
 from hackagent.attacks.techniques.bon.generation import augment_text
 from hackagent.attacks.techniques.cipherchat.encode_experts import encode_expert_dict
 from hackagent.attacks.techniques.h4rm3l.config import PRESET_PROGRAMS
 from hackagent.attacks.techniques.h4rm3l.decorators import (
     compile_program,
     program_uses_llm_assisted_decorators,
+)
+from hackagent.attacks.techniques.pap.config import ALL_TECHNIQUES, TOP_5_TECHNIQUES
+from hackagent.attacks.techniques.pap.taxonomy import (
+    build_mutation_prompt,
+    extract_mutated_text,
+    get_technique_names,
 )
 from hackagent.router.router import AgentRouter
 
@@ -29,6 +36,7 @@ SUPPORTED_JAILBREAK_TECHNIQUES = (
     "flipattack",
     "cipherchat",
     "bon",
+    "pap",
 )
 
 DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
@@ -46,7 +54,14 @@ DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     # bon options
     "sigma": 0.4,
     "seed": 0,
+    # pap options (LLM-assisted — uses the RAG attack's own attacker LLM)
+    "pap_techniques": "top5",
 }
+
+# Hardcoded attacker-LLM call params for LLM-assisted techniques (pap, fc).
+# Not exposed as config — keeps the jailbreak config surface thin.
+_PAP_ATTACKER_MAX_TOKENS = 300
+_PAP_ATTACKER_TEMPERATURE = 1.0
 
 
 class JailbreakFramer:
@@ -236,12 +251,70 @@ def _build_bon_framer(
     return JailbreakFramer("bon", _transform)
 
 
+def _resolve_pap_techniques(config: Dict[str, Any]) -> List[str]:
+    raw = config.get("pap_techniques", "top5")
+    if isinstance(raw, list):
+        techniques = [str(t) for t in raw]
+    elif raw == "all":
+        techniques = list(ALL_TECHNIQUES)
+    else:
+        techniques = list(TOP_5_TECHNIQUES)
+
+    valid = set(get_technique_names())
+    for technique in techniques:
+        if technique not in valid:
+            raise ValueError(
+                f"Unknown PAP persuasion technique '{technique}'. "
+                f"Supported: {sorted(valid)}"
+            )
+    return techniques
+
+
+def _build_pap_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
+    if attacker_router is None or attacker_reg_key is None:
+        raise ValueError(
+            "The 'pap' jailbreak technique requires an attacker LLM router; "
+            "none was provided."
+        )
+    techniques = _resolve_pap_techniques(config)
+
+    def _transform(goal: str, variant_index: int) -> Tuple[str, Dict[str, Any]]:
+        technique = techniques[variant_index % len(techniques)]
+        prompt = build_mutation_prompt(goal, technique)
+        try:
+            response = attacker_router.route_request(
+                registration_key=attacker_reg_key,
+                request_data={
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": _PAP_ATTACKER_MAX_TOKENS,
+                    "temperature": _PAP_ATTACKER_TEMPERATURE,
+                },
+            )
+            mutated = extract_mutated_text(extract_response_content(response) or "")
+        except Exception as e:
+            if logger is not None:
+                logger.warning(f"pap jailbreak attacker LLM failed: {e}")
+            mutated = ""
+
+        if not mutated.strip():
+            return goal, {"technique_name": technique, "pap_fallback": True}
+        return mutated, {"technique_name": technique, "pap_fallback": False}
+
+    return JailbreakFramer("pap", _transform)
+
+
 _TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
     "static_template": _build_static_template_framer,
     "h4rm3l": _build_h4rm3l_framer,
     "flipattack": _build_flipattack_framer,
     "cipherchat": _build_cipherchat_framer,
     "bon": _build_bon_framer,
+    "pap": _build_pap_framer,
 }
 
 

--- a/hackagent/attacks/techniques/rag/jailbreak.py
+++ b/hackagent/attacks/techniques/rag/jailbreak.py
@@ -14,6 +14,7 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from hackagent.attacks.generator import AttackTemplates
+from hackagent.attacks.techniques.cipherchat.encode_experts import encode_expert_dict
 from hackagent.attacks.techniques.h4rm3l.config import PRESET_PROGRAMS
 from hackagent.attacks.techniques.h4rm3l.decorators import (
     compile_program,
@@ -21,7 +22,12 @@ from hackagent.attacks.techniques.h4rm3l.decorators import (
 )
 from hackagent.router.router import AgentRouter
 
-SUPPORTED_JAILBREAK_TECHNIQUES = ("static_template", "h4rm3l", "flipattack")
+SUPPORTED_JAILBREAK_TECHNIQUES = (
+    "static_template",
+    "h4rm3l",
+    "flipattack",
+    "cipherchat",
+)
 
 DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     "enabled": False,
@@ -33,6 +39,8 @@ DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     "syntax_version": 2,
     # flipattack options
     "flip_mode": "FCS",
+    # cipherchat options
+    "encode_method": "caesar",
 }
 
 
@@ -171,10 +179,37 @@ def _build_flipattack_framer(
     return JailbreakFramer("flipattack", _transform)
 
 
+def _build_cipherchat_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
+    raw_methods = config.get("encode_methods") or [
+        config.get("encode_method", "caesar")
+    ]
+    if isinstance(raw_methods, str):
+        raw_methods = [raw_methods]
+    methods = [str(m).strip().lower() for m in raw_methods]
+    for method in methods:
+        if method not in encode_expert_dict:
+            raise ValueError(
+                f"Unsupported cipherchat encode_method '{method}'. "
+                f"Supported: {sorted(encode_expert_dict)}"
+            )
+
+    def _transform(goal: str, variant_index: int) -> Tuple[str, Dict[str, Any]]:
+        method = methods[variant_index % len(methods)]
+        return encode_expert_dict[method].encode(goal), {"encode_method": method}
+
+    return JailbreakFramer("cipherchat", _transform)
+
+
 _TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
     "static_template": _build_static_template_framer,
     "h4rm3l": _build_h4rm3l_framer,
     "flipattack": _build_flipattack_framer,
+    "cipherchat": _build_cipherchat_framer,
 }
 
 

--- a/hackagent/attacks/techniques/rag/jailbreak.py
+++ b/hackagent/attacks/techniques/rag/jailbreak.py
@@ -21,7 +21,7 @@ from hackagent.attacks.techniques.h4rm3l.decorators import (
 )
 from hackagent.router.router import AgentRouter
 
-SUPPORTED_JAILBREAK_TECHNIQUES = ("static_template", "h4rm3l")
+SUPPORTED_JAILBREAK_TECHNIQUES = ("static_template", "h4rm3l", "flipattack")
 
 DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     "enabled": False,
@@ -31,6 +31,8 @@ DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     # h4rm3l options
     "program": "refusal_suppression",
     "syntax_version": 2,
+    # flipattack options
+    "flip_mode": "FCS",
 }
 
 
@@ -126,9 +128,53 @@ def _build_h4rm3l_framer(
     return JailbreakFramer("h4rm3l", _transform)
 
 
+def _flip_word_order(text: str) -> str:
+    return " ".join(text.split()[::-1])
+
+
+def _flip_char_in_word(text: str) -> str:
+    return " ".join(word[::-1] for word in text.split())
+
+
+def _flip_char_in_sentence(text: str) -> str:
+    return text[::-1]
+
+
+_FLIPATTACK_MODES: Dict[str, Callable[[str], str]] = {
+    "FWO": _flip_word_order,
+    "FCW": _flip_char_in_word,
+    "FCS": _flip_char_in_sentence,
+}
+
+
+def _build_flipattack_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
+    raw_modes = config.get("flip_modes") or [config.get("flip_mode", "FCS")]
+    if isinstance(raw_modes, str):
+        raw_modes = [raw_modes]
+    modes = [str(m).strip().upper() for m in raw_modes]
+    for mode in modes:
+        if mode not in _FLIPATTACK_MODES:
+            raise ValueError(
+                f"Unsupported flipattack flip_mode '{mode}'. "
+                f"Supported: {sorted(_FLIPATTACK_MODES)}"
+            )
+
+    def _transform(goal: str, variant_index: int) -> Tuple[str, Dict[str, Any]]:
+        mode = modes[variant_index % len(modes)]
+        return _FLIPATTACK_MODES[mode](goal), {"flip_mode": mode}
+
+    return JailbreakFramer("flipattack", _transform)
+
+
 _TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
     "static_template": _build_static_template_framer,
     "h4rm3l": _build_h4rm3l_framer,
+    "flipattack": _build_flipattack_framer,
 }
 
 

--- a/hackagent/attacks/techniques/rag/jailbreak.py
+++ b/hackagent/attacks/techniques/rag/jailbreak.py
@@ -17,6 +17,12 @@ from hackagent.attacks.generator import AttackTemplates
 from hackagent.attacks.shared.response_utils import extract_response_content
 from hackagent.attacks.techniques.bon.generation import augment_text
 from hackagent.attacks.techniques.cipherchat.encode_experts import encode_expert_dict
+from hackagent.attacks.techniques.fc.flowchart_renderer import TEXT_FORMAT_SERIALIZERS
+from hackagent.attacks.techniques.fc.generation import (
+    _decompose_goal_to_steps,
+    _parse_steps_from_response,
+)
+from hackagent.attacks.techniques.fc.prompts import FEW_SHOT_STEP_DECOMPOSITION
 from hackagent.attacks.techniques.h4rm3l.config import PRESET_PROGRAMS
 from hackagent.attacks.techniques.h4rm3l.decorators import (
     compile_program,
@@ -37,6 +43,7 @@ SUPPORTED_JAILBREAK_TECHNIQUES = (
     "cipherchat",
     "bon",
     "pap",
+    "fc",
 )
 
 DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
@@ -56,12 +63,17 @@ DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     "seed": 0,
     # pap options (LLM-assisted — uses the RAG attack's own attacker LLM)
     "pap_techniques": "top5",
+    # fc options (LLM-assisted, falls back to heuristic decomposition)
+    "fc_num_steps": 6,
+    "fc_text_format": "ascii",
 }
 
 # Hardcoded attacker-LLM call params for LLM-assisted techniques (pap, fc).
 # Not exposed as config — keeps the jailbreak config surface thin.
 _PAP_ATTACKER_MAX_TOKENS = 300
 _PAP_ATTACKER_TEMPERATURE = 1.0
+_FC_ATTACKER_MAX_TOKENS = 300
+_FC_ATTACKER_TEMPERATURE = 0.3
 
 
 class JailbreakFramer:
@@ -308,6 +320,75 @@ def _build_pap_framer(
     return JailbreakFramer("pap", _transform)
 
 
+def _generate_fc_steps_via_llm(
+    goal: str,
+    num_steps: int,
+    attacker_router: AgentRouter,
+    attacker_reg_key: str,
+    logger: Optional[logging.Logger],
+) -> Optional[List[str]]:
+    try:
+        prompt = FEW_SHOT_STEP_DECOMPOSITION.format(goal=goal)
+        response = attacker_router.route_request(
+            registration_key=attacker_reg_key,
+            request_data={
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": _FC_ATTACKER_MAX_TOKENS,
+                "temperature": _FC_ATTACKER_TEMPERATURE,
+            },
+        )
+        generated_text = extract_response_content(response) or ""
+        if generated_text:
+            return _parse_steps_from_response(generated_text, num_steps)
+    except Exception as e:
+        if logger is not None:
+            logger.warning(f"fc jailbreak step generator failed, using fallback: {e}")
+    return None
+
+
+def _build_fc_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
+    if attacker_router is None or attacker_reg_key is None:
+        raise ValueError(
+            "The 'fc' jailbreak technique requires an attacker LLM router; "
+            "none was provided."
+        )
+
+    raw_num_steps = config.get("fc_num_steps", 6)
+    try:
+        num_steps = max(2, int(raw_num_steps))
+    except (TypeError, ValueError):
+        num_steps = 6
+
+    text_format = str(config.get("fc_text_format", "ascii")).strip().lower()
+    serializer = TEXT_FORMAT_SERIALIZERS.get(text_format)
+    if serializer is None:
+        raise ValueError(
+            f"Unsupported fc text_format '{text_format}'. "
+            f"Supported: {sorted(TEXT_FORMAT_SERIALIZERS)}"
+        )
+
+    def _transform(goal: str, variant_index: int) -> Tuple[str, Dict[str, Any]]:
+        steps = _generate_fc_steps_via_llm(
+            goal, num_steps, attacker_router, attacker_reg_key, logger
+        )
+        used_llm = steps is not None
+        if not steps:
+            steps = _decompose_goal_to_steps(goal, num_steps)
+        framed = serializer(goal, steps)
+        return framed, {
+            "text_format": text_format,
+            "num_steps": len(steps),
+            "llm_assisted": used_llm,
+        }
+
+    return JailbreakFramer("fc", _transform)
+
+
 _TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
     "static_template": _build_static_template_framer,
     "h4rm3l": _build_h4rm3l_framer,
@@ -315,6 +396,7 @@ _TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
     "cipherchat": _build_cipherchat_framer,
     "bon": _build_bon_framer,
     "pap": _build_pap_framer,
+    "fc": _build_fc_framer,
 }
 
 

--- a/hackagent/attacks/techniques/rag/jailbreak.py
+++ b/hackagent/attacks/techniques/rag/jailbreak.py
@@ -4,10 +4,10 @@
 """
 Jailbreak framing for the RAG poisoning pipeline.
 
-Reuses existing jailbreak techniques (static templates and h4rm3l decorator
-programs) to reframe the attacker goal before the poisoner LLM turns it into a
-document payload. The reframed goal is what gets embedded in poisoned
-documents; judging still uses the original goal.
+Reuses existing jailbreak techniques (static templates, h4rm3l decorator
+programs, and others) to reframe the attacker goal before the poisoner LLM
+turns it into a document payload. The reframed goal is what gets embedded in
+poisoned documents; judging still uses the original goal.
 """
 
 import logging
@@ -19,6 +19,7 @@ from hackagent.attacks.techniques.h4rm3l.decorators import (
     compile_program,
     program_uses_llm_assisted_decorators,
 )
+from hackagent.router.router import AgentRouter
 
 SUPPORTED_JAILBREAK_TECHNIQUES = ("static_template", "h4rm3l")
 
@@ -66,7 +67,12 @@ def _collect_static_templates(categories: List[str]) -> List[Tuple[str, str]]:
     return templates
 
 
-def _build_static_template_framer(config: Dict[str, Any]) -> JailbreakFramer:
+def _build_static_template_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
     raw_categories = config.get("template_categories") or ["role_play"]
     if isinstance(raw_categories, str):
         raw_categories = [raw_categories]
@@ -90,7 +96,12 @@ def _build_static_template_framer(config: Dict[str, Any]) -> JailbreakFramer:
     return JailbreakFramer("static_template", _transform)
 
 
-def _build_h4rm3l_framer(config: Dict[str, Any]) -> JailbreakFramer:
+def _build_h4rm3l_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
     program_name = str(config.get("program", "refusal_suppression"))
     program = PRESET_PROGRAMS.get(program_name, program_name)
 
@@ -115,31 +126,46 @@ def _build_h4rm3l_framer(config: Dict[str, Any]) -> JailbreakFramer:
     return JailbreakFramer("h4rm3l", _transform)
 
 
+_TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
+    "static_template": _build_static_template_framer,
+    "h4rm3l": _build_h4rm3l_framer,
+}
+
+
 def build_jailbreak_framer(
     config: Optional[Dict[str, Any]],
     logger: logging.Logger,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
 ) -> Optional[JailbreakFramer]:
     """Build a :class:`JailbreakFramer` from a ``poisoning.jailbreak`` config.
 
     Returns ``None`` when jailbreak framing is disabled or unconfigured.
 
+    Args:
+        config: The ``poisoning.jailbreak`` config dict.
+        logger: Logger for status/warning messages.
+        attacker_router: Attacker LLM router, required by LLM-assisted
+            techniques (``pap``, ``fc``). Ignored by purely syntactic ones.
+        attacker_reg_key: Registration key for ``attacker_router``.
+
     Raises:
-        ValueError: If the configuration requests an unsupported technique or
-            an unusable template/program.
+        ValueError: If the configuration requests an unsupported technique,
+            an unusable template/program, or an LLM-assisted technique
+            without an attacker router.
     """
     if not isinstance(config, dict) or not config.get("enabled", False):
         return None
 
     technique = str(config.get("technique", "static_template")).strip().lower()
-    if technique == "static_template":
-        framer = _build_static_template_framer(config)
-    elif technique == "h4rm3l":
-        framer = _build_h4rm3l_framer(config)
-    else:
+    builder = _TECHNIQUE_BUILDERS.get(technique)
+    if builder is None:
         raise ValueError(
             f"Unsupported jailbreak technique '{technique}'. "
             f"Supported: {list(SUPPORTED_JAILBREAK_TECHNIQUES)}"
         )
+
+    framer = builder(config, logger, attacker_router, attacker_reg_key)
 
     logger.info(f"Jailbreak framing enabled for RAG poisoning: {technique}")
     return framer

--- a/hackagent/attacks/techniques/rag/jailbreak.py
+++ b/hackagent/attacks/techniques/rag/jailbreak.py
@@ -14,6 +14,7 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from hackagent.attacks.generator import AttackTemplates
+from hackagent.attacks.techniques.bon.generation import augment_text
 from hackagent.attacks.techniques.cipherchat.encode_experts import encode_expert_dict
 from hackagent.attacks.techniques.h4rm3l.config import PRESET_PROGRAMS
 from hackagent.attacks.techniques.h4rm3l.decorators import (
@@ -27,6 +28,7 @@ SUPPORTED_JAILBREAK_TECHNIQUES = (
     "h4rm3l",
     "flipattack",
     "cipherchat",
+    "bon",
 )
 
 DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
@@ -41,6 +43,9 @@ DEFAULT_JAILBREAK_CONFIG: Dict[str, Any] = {
     "flip_mode": "FCS",
     # cipherchat options
     "encode_method": "caesar",
+    # bon options
+    "sigma": 0.4,
+    "seed": 0,
 }
 
 
@@ -205,11 +210,38 @@ def _build_cipherchat_framer(
     return JailbreakFramer("cipherchat", _transform)
 
 
+def _build_bon_framer(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    attacker_router: Optional[AgentRouter] = None,
+    attacker_reg_key: Optional[str] = None,
+) -> JailbreakFramer:
+    raw_sigma = config.get("sigma", 0.4)
+    try:
+        sigma = float(raw_sigma)
+    except (TypeError, ValueError):
+        sigma = 0.4
+
+    raw_seed = config.get("seed", 0)
+    try:
+        base_seed = int(raw_seed)
+    except (TypeError, ValueError):
+        base_seed = 0
+
+    def _transform(goal: str, variant_index: int) -> Tuple[str, Dict[str, Any]]:
+        seed = base_seed + variant_index
+        framed = augment_text(goal, sigma, seed)
+        return framed, {"sigma": sigma, "seed": seed}
+
+    return JailbreakFramer("bon", _transform)
+
+
 _TECHNIQUE_BUILDERS: Dict[str, Callable[..., JailbreakFramer]] = {
     "static_template": _build_static_template_framer,
     "h4rm3l": _build_h4rm3l_framer,
     "flipattack": _build_flipattack_framer,
     "cipherchat": _build_cipherchat_framer,
+    "bon": _build_bon_framer,
 }
 
 

--- a/tests/unit/attacks/rag/test_jailbreak.py
+++ b/tests/unit/attacks/rag/test_jailbreak.py
@@ -102,5 +102,54 @@ class TestH4rm3lFramer(unittest.TestCase):
             )
 
 
+class TestFlipattackFramer(unittest.TestCase):
+    def test_default_mode_reverses_sentence(self):
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "flipattack"}, LOGGER
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertEqual(framed, "do the bad thing"[::-1])
+        self.assertEqual(metadata["technique"], "flipattack")
+        self.assertEqual(metadata["flip_mode"], "FCS")
+
+    def test_word_order_mode(self):
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "flipattack", "flip_mode": "FWO"},
+            LOGGER,
+        )
+        framed, _ = framer.apply("do the bad thing")
+        self.assertEqual(framed, "thing bad the do")
+
+    def test_char_in_word_mode(self):
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "flipattack", "flip_mode": "FCW"},
+            LOGGER,
+        )
+        framed, _ = framer.apply("do bad")
+        self.assertEqual(framed, "od dab")
+
+    def test_variant_index_rotates_modes(self):
+        framer = build_jailbreak_framer(
+            {
+                "enabled": True,
+                "technique": "flipattack",
+                "flip_modes": ["FWO", "FCS"],
+            },
+            LOGGER,
+        )
+        first, meta_first = framer.apply("do the bad thing", 0)
+        second, meta_second = framer.apply("do the bad thing", 1)
+        self.assertNotEqual(first, second)
+        self.assertEqual(meta_first["flip_mode"], "FWO")
+        self.assertEqual(meta_second["flip_mode"], "FCS")
+
+    def test_unsupported_mode_raises(self):
+        with self.assertRaises(ValueError):
+            build_jailbreak_framer(
+                {"enabled": True, "technique": "flipattack", "flip_mode": "NOPE"},
+                LOGGER,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/attacks/rag/test_jailbreak.py
+++ b/tests/unit/attacks/rag/test_jailbreak.py
@@ -151,5 +151,42 @@ class TestFlipattackFramer(unittest.TestCase):
             )
 
 
+class TestCipherchatFramer(unittest.TestCase):
+    def test_default_method_is_caesar(self):
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "cipherchat"}, LOGGER
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertNotEqual(framed, "do the bad thing")
+        self.assertEqual(metadata["technique"], "cipherchat")
+        self.assertEqual(metadata["encode_method"], "caesar")
+
+    def test_variant_index_rotates_methods(self):
+        framer = build_jailbreak_framer(
+            {
+                "enabled": True,
+                "technique": "cipherchat",
+                "encode_methods": ["caesar", "atbash"],
+            },
+            LOGGER,
+        )
+        first, meta_first = framer.apply("do the bad thing", 0)
+        second, meta_second = framer.apply("do the bad thing", 1)
+        self.assertNotEqual(first, second)
+        self.assertEqual(meta_first["encode_method"], "caesar")
+        self.assertEqual(meta_second["encode_method"], "atbash")
+
+    def test_unsupported_method_raises(self):
+        with self.assertRaises(ValueError):
+            build_jailbreak_framer(
+                {
+                    "enabled": True,
+                    "technique": "cipherchat",
+                    "encode_method": "does_not_exist",
+                },
+                LOGGER,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/attacks/rag/test_jailbreak.py
+++ b/tests/unit/attacks/rag/test_jailbreak.py
@@ -303,5 +303,74 @@ class TestPapFramer(unittest.TestCase):
         self.assertTrue(metadata["pap_fallback"])
 
 
+class TestFcFramer(unittest.TestCase):
+    def test_requires_attacker_router(self):
+        with self.assertRaises(ValueError):
+            build_jailbreak_framer({"enabled": True, "technique": "fc"}, LOGGER)
+
+    def test_frames_goal_with_llm_steps(self):
+        router = MagicMock()
+        router.route_request.return_value = {
+            "generated_text": "1. Step one.\n2. Step two.\n3. Step three."
+        }
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "fc", "fc_num_steps": 3},
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertIn("Step one", framed)
+        self.assertEqual(metadata["technique"], "fc")
+        self.assertEqual(metadata["text_format"], "ascii")
+        self.assertTrue(metadata["llm_assisted"])
+
+    def test_attacker_failure_falls_back_to_heuristic_steps(self):
+        router = MagicMock()
+        router.route_request.side_effect = RuntimeError("boom")
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "fc", "fc_num_steps": 3},
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertTrue(framed)
+        self.assertFalse(metadata["llm_assisted"])
+
+    def test_unsupported_text_format_raises(self):
+        with self.assertRaises(ValueError):
+            build_jailbreak_framer(
+                {
+                    "enabled": True,
+                    "technique": "fc",
+                    "fc_text_format": "does_not_exist",
+                },
+                LOGGER,
+                attacker_router=MagicMock(),
+                attacker_reg_key="attacker",
+            )
+
+    def test_mermaid_text_format(self):
+        router = MagicMock()
+        router.route_request.return_value = {
+            "generated_text": "1. Step one.\n2. Step two."
+        }
+        framer = build_jailbreak_framer(
+            {
+                "enabled": True,
+                "technique": "fc",
+                "fc_num_steps": 2,
+                "fc_text_format": "mermaid",
+            },
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertEqual(metadata["text_format"], "mermaid")
+        self.assertIn("Step one", framed)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/attacks/rag/test_jailbreak.py
+++ b/tests/unit/attacks/rag/test_jailbreak.py
@@ -3,7 +3,9 @@
 
 import logging
 import unittest
+from unittest.mock import MagicMock
 
+from hackagent.attacks.techniques.pap.config import TOP_5_TECHNIQUES
 from hackagent.attacks.techniques.rag.jailbreak import (
     DEFAULT_JAILBREAK_CONFIG,
     build_jailbreak_framer,
@@ -212,6 +214,93 @@ class TestBonFramer(unittest.TestCase):
         _, meta_second = framer.apply("do the bad thing", 1)
         self.assertEqual(meta_first["seed"], 0)
         self.assertEqual(meta_second["seed"], 1)
+
+
+class TestPapFramer(unittest.TestCase):
+    def test_requires_attacker_router(self):
+        with self.assertRaises(ValueError):
+            build_jailbreak_framer({"enabled": True, "technique": "pap"}, LOGGER)
+
+    def test_frames_goal_with_mocked_attacker(self):
+        router = MagicMock()
+        router.route_request.return_value = {
+            "generated_text": (
+                "#the_core_specific_harmful_or_unlawful_intention: x\n"
+                "#mutated_text_with_same_specific_harmful_or_unlawful_intention: "
+                "persuaded framing of the goal"
+            )
+        }
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "pap"},
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertEqual(framed, "persuaded framing of the goal")
+        self.assertEqual(metadata["technique"], "pap")
+        self.assertIn(metadata["technique_name"], TOP_5_TECHNIQUES)
+        router.route_request.assert_called_once()
+        self.assertEqual(
+            router.route_request.call_args.kwargs["registration_key"], "attacker"
+        )
+
+    def test_variant_index_rotates_techniques(self):
+        router = MagicMock()
+        router.route_request.return_value = {"generated_text": "mutated"}
+        framer = build_jailbreak_framer(
+            {
+                "enabled": True,
+                "technique": "pap",
+                "pap_techniques": ["Logical Appeal", "Misrepresentation"],
+            },
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        _, meta_first = framer.apply("goal", 0)
+        _, meta_second = framer.apply("goal", 1)
+        self.assertEqual(meta_first["technique_name"], "Logical Appeal")
+        self.assertEqual(meta_second["technique_name"], "Misrepresentation")
+
+    def test_unknown_technique_name_raises(self):
+        with self.assertRaises(ValueError):
+            build_jailbreak_framer(
+                {
+                    "enabled": True,
+                    "technique": "pap",
+                    "pap_techniques": ["not_a_real_technique"],
+                },
+                LOGGER,
+                attacker_router=MagicMock(),
+                attacker_reg_key="attacker",
+            )
+
+    def test_attacker_failure_falls_back_to_original_goal(self):
+        router = MagicMock()
+        router.route_request.side_effect = RuntimeError("boom")
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "pap"},
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertEqual(framed, "do the bad thing")
+        self.assertTrue(metadata["pap_fallback"])
+
+    def test_empty_attacker_response_falls_back_to_original_goal(self):
+        router = MagicMock()
+        router.route_request.return_value = {"generated_text": ""}
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "pap"},
+            LOGGER,
+            attacker_router=router,
+            attacker_reg_key="attacker",
+        )
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertEqual(framed, "do the bad thing")
+        self.assertTrue(metadata["pap_fallback"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/attacks/rag/test_jailbreak.py
+++ b/tests/unit/attacks/rag/test_jailbreak.py
@@ -188,5 +188,31 @@ class TestCipherchatFramer(unittest.TestCase):
             )
 
 
+class TestBonFramer(unittest.TestCase):
+    def test_frames_goal(self):
+        framer = build_jailbreak_framer({"enabled": True, "technique": "bon"}, LOGGER)
+        framed, metadata = framer.apply("do the bad thing")
+        self.assertNotEqual(framed, "do the bad thing")
+        self.assertEqual(metadata["technique"], "bon")
+        self.assertEqual(metadata["seed"], 0)
+
+    def test_same_seed_is_deterministic(self):
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "bon", "seed": 7}, LOGGER
+        )
+        first, _ = framer.apply("do the bad thing", 0)
+        second, _ = framer.apply("do the bad thing", 0)
+        self.assertEqual(first, second)
+
+    def test_variant_index_changes_seed(self):
+        framer = build_jailbreak_framer(
+            {"enabled": True, "technique": "bon", "seed": 0}, LOGGER
+        )
+        _, meta_first = framer.apply("do the bad thing", 0)
+        _, meta_second = framer.apply("do the bad thing", 1)
+        self.assertEqual(meta_first["seed"], 0)
+        self.assertEqual(meta_second["seed"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Stacked on #527. Extends `JailbreakFramer` (`hackagent/attacks/techniques/rag/jailbreak.py`) from 2 to 7 supported techniques, reusing existing attack-technique packages rather than reimplementing them:

- `flipattack` — word/char/sentence reversal (no LLM)
- `cipherchat` — classical ciphers via the existing `encode_expert_dict` registry (no LLM)
- `bon` — text perturbation via the existing `augment_text` (no LLM)
- `pap` — persuasion-taxonomy paraphrase via the RAG attack's own attacker LLM, with fallback to the original goal on failure
- `fc` — LLM step-decomposition rendered as flowchart text, with fallback to an existing heuristic decomposer on failure

Dispatch was refactored from if/elif to a `technique name → builder` registry, and `build_jailbreak_framer()` now optionally accepts the attacker LLM router so the two LLM-assisted techniques can reuse the poisoner's existing router — no new router/config section.

Kept deliberately minimal: only `rag/jailbreak.py`, `rag/attack.py` (one call site), and the test file are touched — no other package under `attacks/techniques/` was modified, even where that meant a few lines of duplicated logic (flipattack transforms) or importing a private helper from another module (`fc/generation.py`'s step decomposer) rather than promoting it to public.

## Test plan
- [x] `pytest tests/unit/attacks/rag/` — 88 passed (66 baseline + 22 new)
- [x] Full unit suite — 2787 passed, 0 failed
- [x] `ruff check` / `ruff format --check` — clean
- [x] Config round-trips cleanly through `RagConfig` with all 7 techniques present
- [x] Built via subagent-driven development: each of the 7 tasks independently implemented (TDD) and reviewed, plus a final whole-branch review — all clean, no Critical/Important findings outstanding