### PR TITLE
fix(web): stop killing unrelated processes on the dashboard port

### DIFF
--- a/hackagent/cli/commands/web.py
+++ b/hackagent/cli/commands/web.py
@@ -11,10 +11,80 @@ In remote mode (API key configured), opens the cloud dashboard at
 https://app.hackagent.dev.
 """
 
+import os
+import signal
+import socket
+import subprocess
+import time
+
 import click
 from rich.console import Console
 
 console = Console()
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    """Return True if a process is listening on ``host:port``."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex((host, port)) == 0
+
+
+def _listener_pids(port: int) -> list[str]:
+    """Return the PIDs listening on ``port`` (POSIX only; empty otherwise)."""
+    try:
+        out = subprocess.check_output(
+            ["lsof", "-t", "-i", f"TCP:{port}", "-sTCP:LISTEN"],
+            text=True,
+        ).strip()
+    except Exception:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip().isdigit()]
+
+
+def _is_hackagent_process(pid: str) -> bool:
+    """Return True if ``pid``'s command line identifies a HackAgent process."""
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", pid, "-o", "command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return False
+    return "hackagent" in out.lower()
+
+
+def _free_port(host: str, port: int) -> bool:
+    """Reclaim ``host:port`` if a previous HackAgent dashboard holds it.
+
+    Only a process whose command line identifies it as HackAgent is
+    terminated. If the port is held by an unrelated process it is left
+    untouched and ``False`` is returned so the caller can fail with a clear
+    message instead of killing an unrelated service.
+    """
+    if not _port_in_use(host, port):
+        return True  # port already free
+
+    pids = _listener_pids(port)
+    if not pids:
+        # Could not enumerate the listener(s): refuse rather than risk a kill.
+        return False
+
+    for pid in pids:
+        if not _is_hackagent_process(pid):
+            return False  # foreign process — never kill it
+        console.print(
+            f"[yellow]Stopping previous HackAgent instance on port {port} "
+            f"(PID {pid})…[/yellow]"
+        )
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except Exception:
+            return False
+
+    # Give the terminated process a moment to release the socket before bind.
+    time.sleep(0.5)
+    return True
 
 
 @click.command("web")
@@ -113,38 +183,17 @@ def web(ctx, host, port, db_path, no_browser):
     console.print()
     console.print("    Press [bold]Ctrl+C[/bold] to stop.\n")
 
-    # ── Free port if still occupied by a previous instance ──────────────────
-    import signal
-    import socket
-
-    def _free_port(host: str, port: int) -> None:
-        """Kill any process listening on host:port so we can bind cleanly."""
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            if s.connect_ex((host, port)) != 0:
-                return  # port already free
-        try:
-            import subprocess
-
-            out = subprocess.check_output(
-                ["lsof", "-t", "-i", f"TCP:{port}", "-sTCP:LISTEN"],
-                text=True,
-            ).strip()
-            for pid in out.splitlines():
-                pid = pid.strip()
-                if pid.isdigit():
-                    console.print(
-                        f"[yellow]Killing previous process on port {port} (PID {pid})…[/yellow]"
-                    )
-                    import os
-
-                    os.kill(int(pid), signal.SIGTERM)
-            import time
-
-            time.sleep(0.5)
-        except Exception:
-            pass
-
-    _free_port(host, port)
+    # ── Reclaim the port only if a previous HackAgent instance holds it ──────
+    if not _free_port(host, port):
+        console.print(
+            f"[bold red]❌ Port {port} is already in use by another process.[/bold red]"
+        )
+        console.print(
+            "[cyan]Pick a free port with[/cyan] [bold]--port <PORT>[/bold] "
+            "[cyan]or stop the conflicting process first.[/cyan]"
+        )
+        ctx.exit(1)
+        return
 
     # ── Serve (NiceGUI handles browser auto-open via show=...) ──────────────
     app.run(host=host, port=port, show=not no_browser)

--- a/tests/unit/cli/test_web_command.py
+++ b/tests/unit/cli/test_web_command.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from hackagent.cli.commands.web import web
+from hackagent.cli.commands.web import (
+    _free_port,
+    _is_hackagent_process,
+    _listener_pids,
+    web,
+)
 
 
 class _DummyLocalBackend:
@@ -83,6 +88,105 @@ class TestWebCommand(unittest.TestCase):
         mock_local_cls.assert_called_once_with(db_path="/tmp/test-dashboard.db")
         mock_create_app.assert_called_once_with(backend=local_backend)
         app.run.assert_called_once_with(host="127.0.0.1", port=7860, show=False)
+
+
+class TestFreePort(unittest.TestCase):
+    """Test the safe port-reclaim behaviour of the web command."""
+
+    def test_free_port_returns_true_when_port_is_free(self):
+        with patch(
+            "hackagent.cli.commands.web._port_in_use", return_value=False
+        ):
+            self.assertTrue(_free_port("127.0.0.1", 7860))
+
+    def test_free_port_kills_only_hackagent_listener(self):
+        with (
+            patch(
+                "hackagent.cli.commands.web._port_in_use", return_value=True
+            ),
+            patch(
+                "hackagent.cli.commands.web._listener_pids",
+                return_value=["4242"],
+            ),
+            patch(
+                "hackagent.cli.commands.web._is_hackagent_process",
+                return_value=True,
+            ),
+            patch("hackagent.cli.commands.web.os.kill") as mock_kill,
+            patch("hackagent.cli.commands.web.time.sleep"),
+        ):
+            self.assertTrue(_free_port("127.0.0.1", 7860))
+            mock_kill.assert_called_once_with(4242, 15)
+
+    def test_free_port_refuses_foreign_listener(self):
+        with (
+            patch(
+                "hackagent.cli.commands.web._port_in_use", return_value=True
+            ),
+            patch(
+                "hackagent.cli.commands.web._listener_pids",
+                return_value=["4242"],
+            ),
+            patch(
+                "hackagent.cli.commands.web._is_hackagent_process",
+                return_value=False,
+            ),
+            patch("hackagent.cli.commands.web.os.kill") as mock_kill,
+        ):
+            self.assertFalse(_free_port("127.0.0.1", 7860))
+            mock_kill.assert_not_called()
+
+    def test_free_port_refuses_when_listener_unknown(self):
+        with (
+            patch(
+                "hackagent.cli.commands.web._port_in_use", return_value=True
+            ),
+            patch(
+                "hackagent.cli.commands.web._listener_pids", return_value=[]
+            ),
+            patch("hackagent.cli.commands.web.os.kill") as mock_kill,
+        ):
+            self.assertFalse(_free_port("127.0.0.1", 7860))
+            mock_kill.assert_not_called()
+
+    def test_is_hackagent_process_matches_command_line(self):
+        with patch(
+            "hackagent.cli.commands.web.subprocess.check_output",
+            return_value="hackagent web --port 7860\n",
+        ):
+            self.assertTrue(_is_hackagent_process("4242"))
+
+    def test_listener_pids_ignores_non_numeric_lines(self):
+        with patch(
+            "hackagent.cli.commands.web.subprocess.check_output",
+            return_value="4242\nnot-a-pid\n7777\n",
+        ):
+            self.assertEqual(_listener_pids(7860), ["4242", "7777"])
+
+    def test_web_local_mode_foreign_port_exits_without_running(self):
+        runner = CliRunner()
+        config = MagicMock()
+        config.api_key = None
+        config.base_url = "https://api.hackagent.dev"
+
+        app = MagicMock()
+        with (
+            patch(
+                "hackagent.server.storage.local.LocalBackend",
+                return_value=_DummyLocalBackend(),
+            ),
+            patch(
+                "hackagent.server.dashboard.create_app", return_value=app
+            ),
+            patch("hackagent.cli.commands.web._free_port", return_value=False),
+        ):
+            result = runner.invoke(
+                web, ["--no-browser"], obj={"config": config}
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        app.run.assert_not_called()
+        self.assertIn("already in use", result.output)
 
 
 if __name__ == "__main__":

--- a/tests/unit/cli/test_web_command.py
+++ b/tests/unit/cli/test_web_command.py
@@ -94,9 +94,7 @@ class TestFreePort(unittest.TestCase):
     """Test the safe port-reclaim behaviour of the web command."""
 
     def test_free_port_returns_true_when_port_is_free(self):
-        with patch(
-            "hackagent.cli.commands.web._port_in_use", return_value=False
-        ):
+        with patch("hackagent.cli.commands.web._port_in_use", return_value=False):
             self.assertTrue(_free_port("127.0.0.1", 7860))
 
     def test_free_port_kills_only_hackagent_listener(self):

--- a/tests/unit/cli/test_web_command.py
+++ b/tests/unit/cli/test_web_command.py
@@ -99,9 +99,7 @@ class TestFreePort(unittest.TestCase):
 
     def test_free_port_kills_only_hackagent_listener(self):
         with (
-            patch(
-                "hackagent.cli.commands.web._port_in_use", return_value=True
-            ),
+            patch("hackagent.cli.commands.web._port_in_use", return_value=True),
             patch(
                 "hackagent.cli.commands.web._listener_pids",
                 return_value=["4242"],
@@ -118,9 +116,7 @@ class TestFreePort(unittest.TestCase):
 
     def test_free_port_refuses_foreign_listener(self):
         with (
-            patch(
-                "hackagent.cli.commands.web._port_in_use", return_value=True
-            ),
+            patch("hackagent.cli.commands.web._port_in_use", return_value=True),
             patch(
                 "hackagent.cli.commands.web._listener_pids",
                 return_value=["4242"],
@@ -136,12 +132,8 @@ class TestFreePort(unittest.TestCase):
 
     def test_free_port_refuses_when_listener_unknown(self):
         with (
-            patch(
-                "hackagent.cli.commands.web._port_in_use", return_value=True
-            ),
-            patch(
-                "hackagent.cli.commands.web._listener_pids", return_value=[]
-            ),
+            patch("hackagent.cli.commands.web._port_in_use", return_value=True),
+            patch("hackagent.cli.commands.web._listener_pids", return_value=[]),
             patch("hackagent.cli.commands.web.os.kill") as mock_kill,
         ):
             self.assertFalse(_free_port("127.0.0.1", 7860))
@@ -173,14 +165,10 @@ class TestFreePort(unittest.TestCase):
                 "hackagent.server.storage.local.LocalBackend",
                 return_value=_DummyLocalBackend(),
             ),
-            patch(
-                "hackagent.server.dashboard.create_app", return_value=app
-            ),
+            patch("hackagent.server.dashboard.create_app", return_value=app),
             patch("hackagent.cli.commands.web._free_port", return_value=False),
         ):
-            result = runner.invoke(
-                web, ["--no-browser"], obj={"config": config}
-            )
+            result = runner.invoke(web, ["--no-browser"], obj={"config": config})
 
         self.assertNotEqual(result.exit_code, 0)
         app.run.assert_not_called()


### PR DESCRIPTION
## Problem

`hackagent web` reclaimed its port by killing **any** process listening on `host:port`:

```python
os.kill(int(pid), signal.SIGTERM)  # unconditionally, for every listener PID
```

If the dashboard is launched on a port that happens to be in use by another service (a database, a dev server, an unrelated app), that process gets silently `SIGTERM`-ed. The convenience of "reclaim my own stale instance" shouldn't come at the cost of killing arbitrary processes.

## Fix

`web.py` now only terminates a listener whose command line identifies it as HackAgent (`ps -p <pid> -o command=` contains `hackagent`). In every other case it refuses:

- **Foreign process on the port** → left untouched, command exits with a clear error suggesting `--port <PORT>`.
- **Listener PID(s) can't be enumerated** (non-POSIX, `lsof` unavailable, permissions) → refuses rather than risk a kill.

The previous "reclaim my own stale instance" behaviour is preserved for the HackAgent case.

## Changes

- Refactored the inline `_free_port` closure into module-level helpers: `_port_in_use`, `_listener_pids`, `_is_hackagent_process`, and `_free_port` (now returns a boolean).
- Added 7 unit tests covering free-port, reclaim-own-instance, foreign-process refusal, unknown-listener refusal, and the command-line-match helper.

## Test plan

```
$ pytest tests/unit/cli/test_web_command.py -q
..........                                                               [100%]
10 passed in 3.45s
```

Ruff (`select = ["E4","E7","E9","F"]`) passes on both changed files.