### PR TITLE
fix(metrics): count successful_attacks with the same predicate as success_rate

### DIFF
--- a/hackagent/attacks/evaluator/metrics.py
+++ b/hackagent/attacks/evaluator/metrics.py
@@ -345,8 +345,11 @@ def calculate_per_goal_metrics(
     for goal, goal_results in grouped.items():
         goal_metrics: Dict[str, Any] = {
             "total_attempts": len(goal_results),
+            # Same predicate as success_rate below: is_successful_result is the
+            # single source of truth for success, so a row that only carries
+            # is_success, scorer_verdict or eval_* votes counts here as well.
             "successful_attacks": sum(
-                1 for r in goal_results if r.get("success", False)
+                1 for r in goal_results if is_successful_result(r)
             ),
             "success_rate": calculate_success_rate(goal_results),
             "majority_vote_asr": calculate_majority_vote_asr(goal_results),

--- a/tests/unit/attacks/test_metrics.py
+++ b/tests/unit/attacks/test_metrics.py
@@ -177,6 +177,39 @@ class TestCalculatePerGoalMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics["g1"]["success_rate"], 1.0)
         self.assertEqual(metrics["g1"]["successful_attacks"], 2)
 
+    def test_successful_attacks_matches_success_rate_without_success_key(self):
+        """successful_attacks and success_rate use the same success predicate.
+
+        PAIR and TAP rows carry ``is_success``, scorer rows carry
+        ``scorer_verdict`` and multi-judge rows carry ``eval_*`` votes — none of
+        them a ``success`` key. ``is_successful_result`` recognises all three,
+        so the per-goal count must agree with the per-goal rate for each.
+        """
+        representations = {
+            "is_success": [
+                {"goal": "g1", "is_success": True},
+                {"goal": "g1", "is_success": False},
+            ],
+            "scorer_verdict": [
+                {"goal": "g1", "scorer_verdict": "harmful"},
+                {"goal": "g1", "scorer_verdict": "safe"},
+            ],
+            "eval_votes": [
+                {"goal": "g1", "eval_j1": 1, "eval_j2": 1},
+                {"goal": "g1", "eval_j1": 0, "eval_j2": 0},
+            ],
+        }
+        for name, results in representations.items():
+            with self.subTest(representation=name):
+                goal = calculate_per_goal_metrics(results)["g1"]
+                self.assertEqual(goal["total_attempts"], 2)
+                self.assertEqual(goal["successful_attacks"], 1)
+                self.assertAlmostEqual(goal["success_rate"], 0.5)
+                self.assertEqual(
+                    goal["successful_attacks"],
+                    round(goal["success_rate"] * goal["total_attempts"]),
+                )
+
 
 class TestMajorityVoteASR(unittest.TestCase):
     """Tests for calculate_majority_vote_asr function."""


### PR DESCRIPTION
## What this fixes

`calculate_per_goal_metrics` reports two numbers per goal that are supposed to describe the same thing, and they can disagree.

`successful_attacks` counts rows where `r.get("success", False)` is truthy. `success_rate`, three lines below, goes through `calculate_success_rate`, which uses `is_successful_result` - the function the module itself describes as *"the single source of truth for that determination, reused by summary metrics as well as multi-attack chaining"* (`metrics.py:99-108`). `is_successful_result` recognises `is_success`, `scorer_verdict`, `success`, `eval_*` votes, `best_score` and `evaluation_status`. The count only looks at `success`.

So for any result row that carries its outcome under another name, the same per-goal block says one thing in the rate and another in the count. The rows PAIR and TAP return are exactly that shape - `goal`, `best_score`, `is_success`, no `success` key (`pair/attack.py:1179-1190`, `tap/generation.py:856-865`):

```
{"total_attempts": 2, "successful_attacks": 0, "success_rate": 0.5}
```

That is the actual output of `generate_summary_report` on two PAIR-shaped rows, one of which succeeded. The existing tests do not catch it because every fixture in `TestCalculatePerGoalMetrics` uses the `success` key, the one representation where both paths happen to agree.

## The change

One line: `successful_attacks` uses `is_successful_result(r)` instead of `r.get("success", False)`, plus a comment saying why. The count and the rate now come from the same predicate, and `hack_chain` (which already calls `is_successful_result` directly, `agent.py:430`) sees the same notion of success as the report.

One test, `test_successful_attacks_matches_success_rate_without_success_key`, with three sub-cases for rows that carry `is_success`, `scorer_verdict`, or `eval_*` votes and no `success` key. Each asserts that `successful_attacks` equals `round(success_rate * total_attempts)`.

`metrics.py` +4/-1 and `tests/unit/attacks/test_metrics.py` +33/-0. No signature, key, or type changes; rows that already carry `success` produce identical output, which the existing 41 tests confirm.

## Verified

- On unmodified `main`, the new test fails on all three sub-cases (`successful_attacks == 0` where `success_rate == 0.5`); the other 41 tests in the module pass. With the change, 42/42 pass.
- `ruff check` and `ruff format --check` are clean on both files.
- The test module was run in isolation against `metrics.py` loaded by path, because importing the `hackagent` package pulls the full runtime (faiss, langchain, textual, nicegui) and I could not complete that install in my environment. The CI matrix (`uv sync`, `pytest tests/unit/`) will run it the normal way; nothing in the change depends on the import path.

## Not changed, for the record

Several functions in this module return `0.0` on an empty result list (`calculate_success_rate`, `calculate_fleiss_kappa`, `calculate_per_judge_strictness`...). A Fleiss' kappa of `0.0` reads as "agreement no better than chance", which is a different statement from "no data". I left this alone: `test_empty_results` pins the `0.0` behaviour in six places, so it is a deliberate contract, and `total_attacks: 0` sits next to those values in the report. Flagging it only because it is adjacent to this fix, not asking for a change.

## AI-assisted contribution note

The change, the test, and this description were drafted with Claude Code (Anthropic). The claims above - the two predicates, the PAIR/TAP row shape, the fixture coverage, the before/after test results, the ruff runs - were each checked by reading the files or executing them, not taken from the model.