### PR TITLE
fix(pap): normalize attacker types and preserve provider credentials

### DIFF
--- a/hackagent/attacks/shared/router_factory.py
+++ b/hackagent/attacks/shared/router_factory.py
@@ -79,6 +79,8 @@ def create_router(
     config: Dict[str, Any],
     logger: Optional[logging.Logger] = None,
     router_name: Optional[str] = None,
+    *,
+    use_backend_api_key: bool = True,
 ) -> Tuple[AgentRouter, str]:
     """
     Create an AgentRouter from a configuration dictionary.
@@ -88,6 +90,8 @@ def create_router(
         config: Configuration dictionary (identifier, endpoint, agent_type, api_key etc.)
         logger: Logger instance.
         router_name: Human-readable name for logging.
+        use_backend_api_key: Retain the legacy storage-key fallback when True.
+            Set False for provider roles that must resolve their own credentials.
 
     Returns:
         Tuple of (AgentRouter, registration_key).
@@ -106,7 +110,7 @@ def create_router(
 
     # ---- API key resolution ----
     # Priority: explicit config key → env var lookup → backend api key
-    api_key = backend.get_api_key() or ""
+    api_key = (backend.get_api_key() or "") if use_backend_api_key else ""
     api_key_config = config.get("api_key")
     if api_key_config:
         env_key = os.environ.get(api_key_config)

--- a/hackagent/attacks/techniques/pap/generation.py
+++ b/hackagent/attacks/techniques/pap/generation.py
@@ -77,10 +77,10 @@ def _create_attacker_router(
     """Create an AgentRouter for the attacker LLM, using the shared create_router function"""
 
     router, _reg_key = create_router(
-            backend=backend,
-            router_name=f"pap-attacker-{attacker_config.get('identifier', 'unknown')[:30]}",
-            config=attacker_config,
-            )
+        backend=backend,
+        router_name=f"pap-attacker-{attacker_config.get('identifier', 'unknown')[:30]}",
+        config=attacker_config,
+    )
 
     return router
 

--- a/hackagent/attacks/techniques/pap/generation.py
+++ b/hackagent/attacks/techniques/pap/generation.py
@@ -21,7 +21,6 @@ Based on: https://arxiv.org/abs/2401.06373
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from hackagent.attacks.shared.router_factory import create_router
 
 from hackagent.attacks.evaluator.inline_step_judge import (
     InlineStepJudge,
@@ -31,6 +30,7 @@ from hackagent.attacks.shared.response_utils import (
     get_guardrail_info,
     is_guardrail_response,
 )
+from hackagent.attacks.shared.router_factory import create_router
 from hackagent.attacks.techniques.config import DEFAULT_MAX_OUTPUT_TOKENS
 from hackagent.router.router import AgentRouter
 
@@ -74,12 +74,13 @@ def _create_attacker_router(
     attacker_config: Dict[str, Any],
     backend: Any,
 ) -> AgentRouter:
-    """Create an AgentRouter for the attacker LLM, using the shared create_router function"""
+    """Create an attacker router with normalized type and provider credentials."""
 
     router, _reg_key = create_router(
         backend=backend,
         router_name=f"pap-attacker-{attacker_config.get('identifier', 'unknown')[:30]}",
         config=attacker_config,
+        use_backend_api_key=False,
     )
 
     return router

--- a/hackagent/attacks/techniques/pap/generation.py
+++ b/hackagent/attacks/techniques/pap/generation.py
@@ -21,6 +21,7 @@ Based on: https://arxiv.org/abs/2401.06373
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from hackagent.attacks.shared.router_factory import create_router
 
 from hackagent.attacks.evaluator.inline_step_judge import (
     InlineStepJudge,
@@ -73,21 +74,15 @@ def _create_attacker_router(
     attacker_config: Dict[str, Any],
     backend: Any,
 ) -> AgentRouter:
-    """Create an AgentRouter for the attacker LLM."""
-    metadata: Dict[str, Any] = {
-        "name": attacker_config.get("identifier"),
-    }
-    api_key = attacker_config.get("api_key")
-    if api_key:
-        metadata["api_key"] = api_key
+    """Create an AgentRouter for the attacker LLM, using the shared create_router function"""
 
-    return AgentRouter(
-        backend=backend,
-        name=f"pap-attacker-{attacker_config.get('identifier', 'unknown')[:30]}",
-        agent_type=attacker_config.get("agent_type", "OPENAI_SDK"),
-        endpoint=attacker_config.get("endpoint") or "",
-        metadata=metadata,
-    )
+    router, _reg_key = create_router(
+            backend=backend,
+            router_name=f"pap-attacker-{attacker_config.get('identifier', 'unknown')[:30]}",
+            config=attacker_config,
+            )
+
+    return router
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/attacks/pap/test_generation.py
+++ b/tests/unit/attacks/pap/test_generation.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from hackagent.attacks.techniques.pap.taxonomy import (
     PERSUASION_TAXONOMY,
@@ -9,10 +9,100 @@ from hackagent.attacks.techniques.pap.taxonomy import (
     extract_mutated_text,
 )
 from hackagent.attacks.techniques.pap.generation import (
+    _create_attacker_router,
     _resolve_techniques,
     _attack_single_goal,
 )
 from hackagent.attacks.techniques.pap.config import TOP_5_TECHNIQUES
+from hackagent.router.types import AgentTypeEnum
+from hackagent.server.storage.local import LocalBackend
+
+
+class TestCreateAttackerRouter(unittest.TestCase):
+    def setUp(self):
+        self.backend = LocalBackend(":memory:")
+        self.addCleanup(self.backend.close)
+        env = patch.dict("os.environ", {}, clear=True)
+        env.start()
+        self.addCleanup(env.stop)
+
+    def test_normalizes_string_and_enum_agent_types(self):
+        for agent_type in ("OLLAMA", "ollama", AgentTypeEnum.OLLAMA):
+            with self.subTest(agent_type=agent_type):
+                router = _create_attacker_router(
+                    {
+                        "identifier": "test-model",
+                        "agent_type": agent_type,
+                        "endpoint": "http://localhost:11434",
+                    },
+                    self.backend,
+                )
+                key = next(iter(router._agent_registry))
+                self.assertEqual(router._agent_types[key], AgentTypeEnum.OLLAMA)
+                self.assertEqual(
+                    router.get_agent_instance(key).litellm_model,
+                    "ollama_chat/test-model",
+                )
+
+    def test_provider_credentials_do_not_use_storage_token(self):
+        cases = (
+            ({}, "fake-provider-env-key"),
+            ({"api_key": None}, "fake-provider-env-key"),
+            ({"api_key": ""}, "fake-provider-env-key"),
+            ({"api_key": "fake-explicit-key"}, "fake-explicit-key"),
+            ({"api_key": "ATTACKER_API_KEY"}, "fake-attacker-env-key"),
+            (
+                {"agent_metadata": {"api_key": "ATTACKER_API_KEY"}},
+                "fake-attacker-env-key",
+            ),
+        )
+        for storage_key in (None, "fake-storage-token"):
+            for config, expected in cases:
+                with (
+                    self.subTest(storage_key=storage_key, config=config),
+                    patch.object(
+                        self.backend, "get_api_key", return_value=storage_key
+                    ) as get_storage_key,
+                    patch.dict(
+                        "os.environ",
+                        {
+                            "OPENAI_API_KEY": "fake-provider-env-key",
+                            "ATTACKER_API_KEY": "fake-attacker-env-key",
+                        },
+                    ),
+                ):
+                    router = _create_attacker_router(
+                        {
+                            "identifier": "test-model",
+                            "agent_type": "OPENAI_SDK",
+                            **config,
+                        },
+                        self.backend,
+                    )
+                    key = next(iter(router._agent_registry))
+                    self.assertEqual(
+                        router.get_agent_instance(key).actual_api_key, expected
+                    )
+                    get_storage_key.assert_not_called()
+
+    def test_custom_endpoint_without_provider_key_uses_placeholder(self):
+        with patch.object(
+            self.backend, "get_api_key", return_value="fake-storage-token"
+        ):
+            router = _create_attacker_router(
+                {
+                    "identifier": "test-model",
+                    "agent_type": "openai",
+                    "endpoint": "http://localhost:8000/v1",
+                },
+                self.backend,
+            )
+        key = next(iter(router._agent_registry))
+        self.assertEqual(router.get_agent_instance(key).actual_api_key, "not-required")
+
+    def test_missing_identifier_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "identifier"):
+            _create_attacker_router({"agent_type": "OLLAMA"}, self.backend)
 
 
 class TestTaxonomy(unittest.TestCase):

--- a/tests/unit/attacks/shared/test_router_factory.py
+++ b/tests/unit/attacks/shared/test_router_factory.py
@@ -83,6 +83,21 @@ class TestCreateRouter:
         call_kwargs = MockRouter.call_args[1]
         assert call_kwargs["adapter_operational_config"]["api_key"] == "test-token-123"
 
+    @pytest.mark.parametrize("api_key", [None, "explicit-provider-key"])
+    @patch("hackagent.attacks.shared.router_factory.AgentRouter")
+    def test_backend_key_fallback_can_be_disabled(
+        self, MockRouter, mock_client, basic_config, api_key
+    ):
+        MockRouter.return_value._agent_registry = {"key-1": MagicMock()}
+        basic_config["api_key"] = api_key
+
+        create_router(mock_client, basic_config, use_backend_api_key=False)
+
+        mock_client.get_api_key.assert_not_called()
+        assert MockRouter.call_args.kwargs["adapter_operational_config"]["api_key"] == (
+            api_key or ""
+        )
+
     @patch("hackagent.attacks.shared.router_factory.AgentRouter")
     def test_api_key_override_from_metadata(
         self, MockRouter, mock_client, basic_config, logger


### PR DESCRIPTION
… in pap/generation.py, the previous function definition doesn't utilize the shared create_router() method which performs all the needed checks and normalizations for agent_type, which caused errors previously, if passed anything other than the AgentTypeEnum of the required agent_type or OPENAI_SDK, causing errors if initialized with OLLAMA since its not the default and no normalization of the input takes place. Instead the shared create_router() from the router_factory in hackagent/attacks/shared/router_factory.py https://github.com/AISecurityLab/hackagent/blob/9ad03f5c91204f6d24a64fca308c0afd9455304a/hackagent/attacks/shared/router_factory.py#L77

Closes the issue: #563 

## Maintainer follow-up: provider credentials and regression coverage

The shared factory now accepts a keyword-only `use_backend_api_key` switch (default `True`, preserving existing callers). PAP opts out so an implicit provider environment key or an unauthenticated local endpoint is not overridden by the HackAgent storage token. Explicit provider credentials and agent-metadata keys still work.

Direct constructor tests cover uppercase/lowercase/enum Ollama types, local and remote storage, absent/empty/explicit/environment/metadata provider keys, local OpenAI-compatible endpoints, and missing identifiers. This addresses the credential regression raised in review without dropping the fix for #563.

### Follow-up validation
- Reproduced the credential failure with new tests before applying the fix.
- 90 targeted PAP/shared-factory/chat-registration/dispatch tests passed.
- Shared router factory: 100% statement coverage in the targeted run; the PAP constructor is exercised directly.
- Ruff lint/format and the repository full-unit-suite pre-commit hook passed.
- Independent code review found no blocking issues.
