### PR TITLE
fix(autodan): use native embedding requests for strategy retrieval

### DIFF
--- a/docs/docs/attacks/autodan_turbo.md
+++ b/docs/docs/attacks/autodan_turbo.md
@@ -135,12 +135,11 @@ advanced_config = {
         "api_key": "${OPENROUTER_API_KEY}"
     },
     "embedder": {
-        "identifier": "gemma3:4b",
+        "identifier": "embeddinggemma:300m",
         "endpoint": "http://localhost:11434",
         "agent_type": "OLLAMA",
         "api_key": None,
-        "max_tokens": 100,
-        "temperature": 0.0
+        "on_error": "disable"
     },
     "category_classifier": {
         "identifier": "gemma3:4b",
@@ -175,13 +174,53 @@ advanced_config = {
 
 ### Embedder Role
 
-AutoDAN-Turbo uses a top-level `embedder` config for strategy retrieval. This role is now fully configurable from `attack_config`.
+AutoDAN-Turbo uses a top-level `embedder` config for strategy retrieval. It sends
+embedding requests through LiteLLM and uses the returned numeric vectors directly
+in FAISS. It never sends chat messages to the embedder or hashes generated text.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `embedder.identifier` | Embedder model used for strategy retrieval | `gemma3:4b` |
-| `embedder.endpoint` | Endpoint used by the embedder router | `http://localhost:11434` |
-| `embedder.agent_type` | Router adapter type for the embedder | `OLLAMA` |
+| `embedder.identifier` | Embedding-capable model used for retrieval | `embeddinggemma` |
+| `embedder.endpoint` | Embedding provider API base or full embedding endpoint | `http://localhost:11434` |
+| `embedder.agent_type` | Embedding provider: `OLLAMA`, `OPENAI_SDK`, or `LITELLM` | `OLLAMA` |
+| `embedder.api_key` | Literal key or environment variable name (`NAME` / `${NAME}`) | `None` |
+| `embedder.on_error` | `disable`: log failure and skip external retrieval for this run; `raise`: propagate the error | `disable` |
+
+For Ollama, base URLs, `/v1`, `/v1/embeddings`, `/api/embed`, and `/api/embeddings`
+are accepted (including trailing slashes). All select Ollama's OpenAI-compatible
+`/v1/embeddings` endpoint. Optional `ollama/` or `ollama_chat/` model prefixes are
+removed before sending the model name. Reverse-proxy path prefixes are preserved.
+
+For OpenAI-compatible providers, use `agent_type="OPENAI_SDK"`. A full
+`.../embeddings` URL is reduced to its API base; a bare origin gets `/v1`.
+Custom API paths such as OpenRouter's `/api/v1` are preserved. Omitting `endpoint`
+uses the OpenAI provider default, not the Ollama default. Set `api_key` explicitly,
+reference an environment variable, or use `OPENAI_API_KEY`; HackAgent storage
+tokens are never reused. On custom compatible endpoints, `identifier` is the
+server-native model ID: names such as `openai/text-embedding-3-small` are preserved
+verbatim. Only the default/official OpenAI service accepts `openai/` as an optional
+routing prefix in `OPENAI_SDK` mode.
+
+`LITELLM` preserves provider-prefixed identifiers and provider environment
+credentials. Native provider bases (for example an Azure resource URL) pass
+through unchanged; they do not acquire an OpenAI-compatible `/v1` suffix.
+OpenAI endpoint normalization applies to `openai/` routes, while `ollama/` and
+`ollama_chat/` routes select the Ollama-compatible endpoint described above.
+
+External failures or malformed/nonfinite/empty vectors **never silently fall back
+to local embeddings**. With the default `on_error="disable"`, the attack continues
+without semantic retrieval after a failure. Choose `on_error="raise"` to fail on
+runtime embedding errors. For deterministic offline retrieval, explicitly select
+`embedder={"identifier": "local/bag-of-words"}` (512-dimensional hashing, no service
+or credentials). Legacy `StrategyLibrary(embedding_model=..., embedding_api_key=...,
+embedding_api_base=...)` arguments remain supported.
+
+Saved libraries record their embedding provider/model/base. Loading a library
+from another vector space discards its vectors while retaining strategy text and
+scores; rebuild it for retrieval. Old unversioned libraries loaded through normal
+provider config also discard vectors because they may contain hashed chat
+signatures. Explicit local and legacy modes can still load their old libraries.
+Malformed or dimension-incompatible stored vectors are skipped before FAISS.
 
 ### Preflight Controls (Advanced)
 
@@ -189,6 +228,12 @@ AutoDAN-Turbo uses a top-level `embedder` config for strategy retrieval. This ro
 |-----------|-------|-------------|---------|
 | `_preflight_require_embedder` | AutoDAN-Turbo | When `true`, `embedder` is treated as required during preflight availability checks. | `false` |
 | `_preflight_probe_optional_roles` | Global (all attacks) | When `true`, preflight also probes roles marked optional by attack-specific role resolution. | `false` |
+
+The embedder remains optional by default; `on_error` does not change preflight
+requirements. Enable `_preflight_require_embedder` to abort before a run if a real
+embedding request fails. When probed, the embedder must return a valid numeric
+vector: model presence or an HTTP success without vectors is insufficient.
+Chat and embedding capabilities are checked separately even for the same model.
 
 ### Role Models
 
@@ -232,5 +277,5 @@ AutoDAN-Turbo currently supports **goal-level batching**.
 - Warm-up and lifelong phases share a single strategy library per run.
 - For custom endpoints, pass `agent_type="OPENAI_SDK"` with the appropriate `endpoint`.
 - Use a fast, cheap scorer to reduce cost. The scorer runs for every attempt.
-- You can set `embedder.identifier` to `local/bag-of-words` for deterministic local retrieval signatures.
+- You can set `embedder.identifier` to `local/bag-of-words` for deterministic local retrieval vectors.
 - The jailbreak condition uses scorer threshold: success when `score >= break_score`.

--- a/hackagent/attacks/orchestrator.py
+++ b/hackagent/attacks/orchestrator.py
@@ -42,6 +42,7 @@ from uuid import UUID
 import httpx
 
 from hackagent.errors import HackAgentError
+from hackagent.attacks.shared.embedding_utils import request_embedding
 from hackagent.router.tracking.audit import record_run_audit_failure
 from hackagent.attacks.techniques.config import (
     DEFAULT_CATEGORY_CLASSIFIER_AGENT_TYPE,
@@ -684,12 +685,19 @@ class AttackOrchestrator:
         by a local Ollama are fetched on first use. Failures are swallowed — the
         probe still reports anything genuinely unreachable.
         """
-        candidates = [
-            str(t.get("identifier"))
-            for t in targets
-            if str(t.get("agent_type") or "").upper() == "OLLAMA"
-            and t.get("identifier")
-        ]
+        candidates = []
+        for target in targets:
+            model = str(target.get("identifier") or "")
+            if str(target.get("agent_type") or "").upper() != "OLLAMA":
+                continue
+            if not model or model.startswith("local/"):
+                continue
+            if target.get("role") == "embedder":
+                for prefix in ("ollama/", "ollama_chat/"):
+                    if model.startswith(prefix):
+                        model = model[len(prefix) :]
+                        break
+            candidates.append(model)
         if not candidates or shutil.which("ollama") is None:
             return
         try:
@@ -944,12 +952,13 @@ class AttackOrchestrator:
         return str(role or "unknown")
 
     @staticmethod
-    def _preflight_target_key(target: Dict[str, Any]) -> Tuple[str, str, str]:
+    def _preflight_target_key(target: Dict[str, Any]) -> Tuple[str, str, str, str]:
         """Build deduplication key for effective model endpoint checks."""
         return (
             str(target.get("identifier") or ""),
             str(target.get("endpoint") or ""),
             str(target.get("agent_type") or ""),
+            "embedding" if target.get("role") == "embedder" else "chat",
         )
 
     def _collect_model_preflight_targets(
@@ -960,7 +969,7 @@ class AttackOrchestrator:
     ) -> List[Dict[str, Any]]:
         """Collect model endpoints that must be reachable before run start."""
         targets: List[Dict[str, Any]] = []
-        targets_by_key: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+        targets_by_key: Dict[Tuple[str, str, str, str], Dict[str, Any]] = {}
 
         def _register_target(
             target: Dict[str, Any],
@@ -1200,54 +1209,18 @@ class AttackOrchestrator:
         return env_value if env_value else raw_text
 
     def _probe_embedding_target(self, target: Dict[str, Any]) -> Optional[str]:
-        """Probe embedding endpoint using an embeddings request instead of chat."""
-        endpoint = str(target.get("endpoint") or "").strip().rstrip("/")
-        identifier = str(target.get("identifier") or "")
-        role_config = (
-            target.get("config") if isinstance(target.get("config"), dict) else {}
-        )
-
-        if not endpoint:
-            return "missing endpoint for embedding health check"
-        if not identifier:
-            return "missing identifier for embedding health check"
-
-        probe_endpoint = endpoint
-        if not probe_endpoint.lower().endswith("/embeddings"):
-            probe_endpoint = f"{probe_endpoint}/embeddings"
-
-        headers: Dict[str, str] = {
-            "Content-Type": "application/json",
-            "User-Agent": "HackAgent/0.1.0",
-        }
-        api_key = self._resolve_probe_api_key(role_config)
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-
-        payload = {
-            "model": identifier,
-            "input": ["healthcheck"],
-        }
-
+        """Verify embedding capability with the same provider path as retrieval."""
+        role_config = dict(target.get("config") or {})
+        for key in ("identifier", "endpoint", "agent_type"):
+            if key not in role_config:
+                role_config[key] = target.get(key)
+        if str(role_config.get("identifier") or "").startswith("local/"):
+            return None
+        role_config["timeout"] = 20.0
         try:
-            response = httpx.post(
-                probe_endpoint,
-                headers=headers,
-                json=payload,
-                timeout=20.0,
-            )
+            request_embedding(role_config, "healthcheck")
         except Exception as exc:
             return f"embedding health check failed ({type(exc).__name__}): {exc}"
-
-        if response.status_code >= 400:
-            body = response.text.strip()
-            if len(body) > 300:
-                body = f"{body[:297]}..."
-            return (
-                f"embedding endpoint returned {response.status_code}: "
-                f"{body or 'empty response body'}"
-            )
-
         return None
 
     def _probe_model_target(self, target: Dict[str, Any]) -> Optional[str]:
@@ -1263,6 +1236,9 @@ class AttackOrchestrator:
             "embedder" in normalized_roles or endpoint.lower().endswith("/embeddings")
         )
 
+        if should_use_embedding_probe:
+            return self._probe_embedding_target(target)
+
         if kind == "existing_router":
             router = target.get("router")
             registration_key = str(target.get("registration_key") or "")
@@ -1271,9 +1247,6 @@ class AttackOrchestrator:
             return self._probe_router_registration(router, registration_key)
 
         if kind == "router_config":
-            if should_use_embedding_probe:
-                return self._probe_embedding_target(target)
-
             from hackagent.attacks.shared.router_factory import create_router
 
             try:

--- a/hackagent/attacks/shared/embedding_utils.py
+++ b/hackagent/attacks/shared/embedding_utils.py
@@ -1,0 +1,145 @@
+# Copyright 2026 - AI4I. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Embedding-only provider requests shared by retrieval and preflight."""
+
+import os
+from typing import Any, Dict, Optional
+from urllib.parse import urlsplit
+
+import numpy as np
+
+from hackagent.config import DEFAULT_EMBEDDER_ENDPOINT
+
+
+def normalize_embedding_endpoint(endpoint: str, *, ollama: bool = False) -> str:
+    """Return an OpenAI-compatible API base, not a full embeddings URL.
+
+    Ollama's native endpoint spellings select its compatible ``/v1`` API.
+    Preserve reverse-proxy prefixes and custom OpenAI-compatible API paths.
+    """
+    base = endpoint.strip().rstrip("/")
+    if ollama:
+        for suffix in ("/api/embed", "/api/embeddings", "/v1/embeddings", "/v1"):
+            if base.lower().endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        return f"{base}/v1"
+    if base.lower().endswith("/embeddings"):
+        return base[: -len("/embeddings")]
+    if not urlsplit(base).path:
+        return f"{base}/v1"
+    return base
+
+
+def embedding_request_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve provider, endpoint and credentials without consulting storage."""
+    model = str(config.get("identifier") or "").strip()
+    if not model:
+        raise ValueError("An embedding model identifier is required")
+    agent_type = config.get("agent_type") or "OPENAI_SDK"
+    agent_type = str(getattr(agent_type, "value", agent_type)).upper()
+    ollama = agent_type == "OLLAMA" or (
+        agent_type == "LITELLM" and model.startswith(("ollama/", "ollama_chat/"))
+    )
+    endpoint = config.get("endpoint")
+    kwargs: Dict[str, Any] = {"model": model, "encoding_format": "float"}
+    if ollama:
+        for prefix in ("ollama/", "ollama_chat/"):
+            if model.startswith(prefix):
+                model = model[len(prefix) :]
+                break
+        kwargs.update(model=model, custom_llm_provider="openai")
+        kwargs["api_base"] = normalize_embedding_endpoint(
+            str(endpoint or DEFAULT_EMBEDDER_ENDPOINT), ollama=True
+        )
+    elif agent_type == "OPENAI_SDK":
+        # Custom compatible servers own their model namespace. Only the OpenAI
+        # service itself treats an optional "openai/" as a routing prefix here.
+        if not endpoint or urlsplit(str(endpoint)).hostname == "api.openai.com":
+            model = model.removeprefix("openai/")
+        kwargs.update(model=model, custom_llm_provider="openai")
+        if endpoint:
+            kwargs["api_base"] = normalize_embedding_endpoint(str(endpoint))
+    elif agent_type == "LITELLM":
+        if endpoint:
+            kwargs["api_base"] = (
+                normalize_embedding_endpoint(str(endpoint))
+                if model.startswith("openai/")
+                else str(endpoint)
+            )
+    else:
+        raise ValueError(f"Unsupported embedding agent_type: {agent_type}")
+
+    raw_key = config.get("api_key")
+    if raw_key:
+        key = str(raw_key)
+        if key.startswith("${") and key.endswith("}"):
+            env_name = key[2:-1]
+            key = os.environ.get(env_name, "")
+            if not key:
+                raise ValueError(
+                    f"Embedding API key environment variable {env_name} is unset"
+                )
+        else:
+            key = os.environ.get(key) or key
+        kwargs["api_key"] = key
+    elif ollama:
+        # Ollama's compatible API needs a client key, but has no default auth.
+        kwargs["api_key"] = "ollama"
+    elif agent_type == "OPENAI_SDK" and os.environ.get("OPENAI_API_KEY"):
+        kwargs["api_key"] = os.environ["OPENAI_API_KEY"]
+    if config.get("timeout") is not None:
+        kwargs["timeout"] = config["timeout"]
+    return kwargs
+
+
+def validate_embedding_vector(
+    value: Any, *, dimension: Optional[int] = None
+) -> np.ndarray:
+    """Require a nonempty, finite, one-dimensional float32 numeric vector."""
+    try:
+        vector = np.asarray(value)
+        if vector.ndim != 1 or not vector.size or vector.dtype.kind not in "fiu":
+            raise ValueError("expected a nonempty numeric vector")
+        with np.errstate(over="ignore", invalid="ignore"):
+            vector = vector.astype(np.float32)
+        if not np.isfinite(vector).all():
+            raise ValueError("embedding contains nonfinite values")
+        if dimension is not None and vector.size != dimension:
+            raise ValueError(
+                f"embedding dimension changed: expected {dimension}, got {vector.size}"
+            )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"Invalid embedding vector: {exc}") from exc
+    return vector
+
+
+def extract_embedding_vector(response: Any) -> np.ndarray:
+    """Extract and validate the single requested vector from a LiteLLM response."""
+    data = (
+        response.get("data")
+        if isinstance(response, dict)
+        else getattr(response, "data", None)
+    )
+    if not isinstance(data, list) or len(data) != 1:
+        raise ValueError("Embedding endpoint returned no single embedding vector")
+    item = data[0]
+    vector = (
+        item.get("embedding")
+        if isinstance(item, dict)
+        else getattr(item, "embedding", None)
+    )
+    return validate_embedding_vector(vector)
+
+
+def request_embedding(config: Dict[str, Any], text: str) -> np.ndarray:
+    """Request a real embedding, never chat completions or textual signatures."""
+    import litellm
+
+    kwargs = embedding_request_kwargs(config)
+    if kwargs.get("custom_llm_provider") == "openai":
+        # LiteLLM consumes one routing prefix, even with custom_llm_provider set.
+        # Add our own so a server-native ID such as "openai/model" stays intact.
+        kwargs["model"] = f"openai/{kwargs['model']}"
+    response = litellm.embedding(input=[text], **kwargs)
+    return extract_embedding_vector(response)

--- a/hackagent/attacks/techniques/autodan_turbo/attack.py
+++ b/hackagent/attacks/techniques/autodan_turbo/attack.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from hackagent.attacks.shared.tui import with_tui_logging
 from hackagent.attacks.techniques.base import BaseAttack
+from hackagent.attacks.techniques.config import resolve_embedder_config
 from hackagent.attacks.types import AttackResult, rows_to_attack_results
 
 from . import autodan_eval as evaluation, lifelong, warm_up
@@ -85,6 +86,8 @@ class AutoDANTurboAttack(BaseAttack):
         if config:
             user_config, internal_config = _split_internal_keys(config)
             _deep_update(cfg, user_config)
+            if "embedder" in user_config:
+                cfg["embedder"] = resolve_embedder_config(user_config["embedder"])
         cfg = AutoDANTurboConfig.from_dict(cfg).to_dict()
         cfg.update(internal_config)
 
@@ -126,7 +129,7 @@ class AutoDANTurboAttack(BaseAttack):
             if isinstance(role_config, dict):
                 roles.append({"role": role_name, "config": role_config})
 
-        embedder = attack_config.get("embedder")
+        embedder = resolve_embedder_config(attack_config.get("embedder"))
         if isinstance(embedder, dict):
             roles.append(
                 {

--- a/hackagent/attacks/techniques/autodan_turbo/config.py
+++ b/hackagent/attacks/techniques/autodan_turbo/config.py
@@ -15,7 +15,7 @@ Based on: https://arxiv.org/abs/2410.05295
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from hackagent.attacks.techniques.config import (
     AttackerConfig,
@@ -25,6 +25,7 @@ from hackagent.attacks.techniques.config import (
     DEFAULT_JUDGE_IDENTIFIER,
     DEFAULT_MAX_OUTPUT_TOKENS,
     default_embedder,
+    resolve_embedder_config,
 )
 
 
@@ -76,6 +77,11 @@ class AutoDANTurboConfig(ConfigBase):
     )
     embedder: Dict[str, Any] = Field(default_factory=default_embedder)
     target_request_overrides: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("embedder", mode="before")
+    @classmethod
+    def _resolve_embedder(cls, value: Any) -> Dict[str, Any]:
+        return resolve_embedder_config(value)
 
     @model_validator(mode="before")
     @classmethod

--- a/hackagent/attacks/techniques/autodan_turbo/strategy_library.py
+++ b/hackagent/attacks/techniques/autodan_turbo/strategy_library.py
@@ -10,9 +10,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from hackagent.attacks.shared.response_utils import extract_response_content
-from hackagent.attacks.shared.router_factory import create_router
-from hackagent.attacks.techniques.config import default_category_classifier
+from hackagent.attacks.shared.embedding_utils import (
+    embedding_request_kwargs,
+    extract_embedding_vector,
+    request_embedding,
+    validate_embedding_vector,
+)
+from hackagent.attacks.techniques.config import resolve_embedder_config
 
 try:
     import faiss
@@ -44,8 +48,9 @@ class StrategyLibrary:
 
         Args:
             embedder_config: Top-level ``embedder`` config from attack config.
-                Uses category-classifier schema/defaults.
-            backend: Storage backend used to initialize an embedder router.
+                Uses embedding-only provider defaults. ``on_error`` is ``disable``
+                (skip retrieval after failure) or ``raise``. No implicit local fallback.
+            backend: Retained for compatibility; never used for model credentials.
             embedding_model: Legacy embedding model argument kept for backward
                 compatibility. Prefer ``embedder_config``.
             embedding_api_key: Legacy API key for OpenAI-compatible embeddings.
@@ -58,8 +63,7 @@ class StrategyLibrary:
         self.library: Dict[str, Dict[str, Any]] = {}
         self.logger = logger or logging.getLogger(__name__)
         self._embedding_disabled_reason: Optional[str] = None
-        self._embedder_router = None
-        self._embedder_registration_key: Optional[str] = None
+        self._embedding_dimension: Optional[int] = None
 
         # Backward compatibility mode: preserve direct embedding endpoint usage
         # when old parameters are explicitly provided.
@@ -73,47 +77,23 @@ class StrategyLibrary:
             self.embedding_api_key = embedding_api_key
             self.embedding_api_base = embedding_api_base
             self.embedder_config = {
-                **default_category_classifier(),
                 "identifier": self.embedding_model,
                 "endpoint": self.embedding_api_base,
                 "api_key": self.embedding_api_key,
-                "agent_type": "OPENAI_SDK",
+                "agent_type": "LITELLM",
+                "on_error": "disable",
             }
         else:
             self.embedder_config = self._resolve_embedder_config(embedder_config)
-            self.embedding_model = str(
-                self.embedder_config.get("identifier") or "local/bag-of-words"
-            )
+            self.embedding_model = self.embedder_config["identifier"].strip()
             self.embedding_api_key = self.embedder_config.get("api_key")
             self.embedding_api_base = self.embedder_config.get("endpoint")
 
-            if not self.embedding_model.startswith("local/") and backend is not None:
-                try:
-                    router, registration_key = create_router(
-                        backend=backend,
-                        config=self.embedder_config,
-                        logger=self.logger,
-                        router_name="autodan-embedder",
-                    )
-                    self._embedder_router = router
-                    self._embedder_registration_key = registration_key
-                except Exception as exc:
-                    self._embedding_disabled_reason = (
-                        "Embedder router unavailable; falling back to local embedding."
-                    )
-                    self.logger.warning(
-                        "%s reason=%s",
-                        self._embedding_disabled_reason,
-                        exc,
-                    )
-
-        backend_mode = "local"
-        if self._legacy_embedding_mode and not self.embedding_model.startswith(
-            "local/"
-        ):
-            backend_mode = "legacy-openai-embeddings"
-        elif self._embedder_router is not None:
-            backend_mode = "router-semantic-signature"
+        backend_mode = (
+            "local"
+            if self.embedding_model.startswith("local/")
+            else "provider-embeddings"
+        )
 
         endpoint_display = (
             self.embedding_api_base
@@ -129,14 +109,7 @@ class StrategyLibrary:
 
     @staticmethod
     def _resolve_embedder_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-        resolved = default_category_classifier()
-        if not config:
-            return resolved
-
-        for key, value in config.items():
-            if value is not None:
-                resolved[key] = value
-        return resolved
+        return resolve_embedder_config(config)
 
     def embed(self, text: str) -> Optional[np.ndarray]:
         """Encode text to an embedding vector for strategy retrieval.
@@ -153,128 +126,38 @@ class StrategyLibrary:
         if self.embedding_model.startswith("local/"):
             return self._local_embed(text)
 
-        if self._legacy_embedding_mode:
-            return self._embed_legacy_openai(text)
-
-        signature = self._build_router_semantic_signature(text)
-        if signature:
-            return self._local_embed(signature)
-
-        # Keep the run alive even if external embedding infrastructure fails.
-        return self._local_embed(text)
-
-    def _build_router_semantic_signature(self, text: str) -> Optional[str]:
-        if not self._embedder_router or not self._embedder_registration_key:
-            return None
-
-        system_prompt = (
-            "You are an embedding proxy. Convert input text into a compact, "
-            "deterministic semantic signature for vector retrieval. "
-            "Output plain text only: key entities, actions, intent, and constraints."
-        )
-        user_prompt = (
-            f"Input:\n{text}\n\nReturn a short semantic signature (max 80 words)."
-        )
-
-        request_data: Dict[str, Any] = {
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            "max_tokens": self.embedder_config.get("max_tokens", 100),
-            "temperature": self.embedder_config.get("temperature", 0.0),
-        }
-
-        try:
-            response = self._embedder_router.route_request(
-                registration_key=self._embedder_registration_key,
-                request_data=request_data,
-            )
-            if isinstance(response, dict) and response.get("error_message"):
-                self.logger.warning(
-                    "Embedder router error: %s",
-                    response.get("error_message"),
-                )
-                return None
-
-            signature = extract_response_content(response, self.logger)
-            if not signature:
-                return None
-            return str(signature).strip()
-        except Exception as exc:
-            self.logger.warning("Embedder semantic signature failed: %s", exc)
-            return None
-
-    def _embed_legacy_openai(self, text: str) -> Optional[np.ndarray]:
         if self._embedding_disabled_reason is not None:
             return None
 
         try:
-            import litellm
-
-            kwargs: Dict[str, Any] = {
-                "model": self.embedding_model,
-                "input": [text],
-                # OpenRouter/OpenAI-compatible embedding endpoints expect
-                # encoding_format to be one of: float|base64.
-                "encoding_format": "float",
-            }
-            if self.embedding_api_base:
-                kwargs["api_base"] = self.embedding_api_base
-            if self.embedding_api_key:
-                kwargs["api_key"] = self.embedding_api_key
-
-            response = litellm.embedding(**kwargs)
-            vector = self._extract_embedding_vector(response)
-            if vector is None:
-                raise ValueError("No embedding data received")
-            return np.array(vector, dtype=np.float32)
+            vector = validate_embedding_vector(
+                request_embedding(self.embedder_config, text),
+                dimension=self._embedding_dimension,
+            )
+            self._embedding_dimension = vector.size
+            return vector
         except Exception as exc:
-            message = str(exc)
-            if "No embedding data received" in message:
-                self._embedding_disabled_reason = (
-                    "Embedding endpoint returned no vectors; the selected model "
-                    "likely does not support /v1/embeddings."
-                )
-                self.logger.error(
-                    "Embedding disabled for this run: %s (model=%s, base=%s)",
-                    self._embedding_disabled_reason,
-                    self.embedding_model,
-                    self.embedding_api_base or "<provider-default>",
-                )
-            else:
-                self.logger.error("Embedding failed: %s", message)
+            self.logger.error(
+                "Embedding failed (model=%s); no local fallback will be used: %s",
+                self.embedding_model,
+                exc,
+                exc_info=True,
+            )
+            if self.embedder_config.get("on_error") == "raise":
+                raise
+            # Preserve legacy transient-error retries. Normal config disables
+            # retrieval for the run rather than silently changing vector spaces.
+            if not self._legacy_embedding_mode or isinstance(exc, ValueError):
+                self._embedding_disabled_reason = str(exc)
             return None
 
     @staticmethod
     def _extract_embedding_vector(response: Any) -> Optional[List[float]]:
-        """Extract first embedding vector from LiteLLM response payload.
-
-        Supports both object-style payloads (response.data[0].embedding)
-        and dict-style payloads ({"data": [{"embedding": [...]}]}).
-        """
-        if response is None:
+        """Compatibility wrapper for the shared validated vector extractor."""
+        try:
+            return extract_embedding_vector(response).tolist()
+        except ValueError:
             return None
-
-        data = None
-        if isinstance(response, dict):
-            data = response.get("data")
-        else:
-            data = getattr(response, "data", None)
-
-        if not isinstance(data, list) or not data:
-            return None
-
-        first = data[0]
-        vector = (
-            first.get("embedding")
-            if isinstance(first, dict)
-            else getattr(first, "embedding", None)
-        )
-        if not isinstance(vector, list):
-            return None
-
-        return vector
 
     def _local_embed(self, text: str, _dim: int = 512) -> np.ndarray:
         """Deterministic hashing-trick bag-of-words embedding (``local/bag-of-words``).
@@ -307,18 +190,25 @@ class StrategyLibrary:
             None.
         """
         name = strategy.get("Strategy", "unknown")
+        fields = {"Example": "", "Score": 0, "Embeddings": None}
+        row_count = max(len(strategy.get(key) or []) for key in fields)
+        values = {
+            key: list(strategy.get(key) or [])
+            + [default] * (row_count - len(strategy.get(key) or []))
+            for key, default in fields.items()
+        }
         if name in self.library:
             existing = self.library[name]
-            for key in ("Example", "Score", "Embeddings"):
-                if key in strategy and strategy[key]:
-                    existing.setdefault(key, []).extend(strategy[key])
+            existing_count = max(len(existing.get(key, [])) for key in fields)
+            for key, default in fields.items():
+                column = existing.setdefault(key, [])
+                column.extend([default] * (existing_count - len(column)))
+                column.extend(values[key])
         else:
             self.library[name] = {
                 "Strategy": name,
                 "Definition": strategy.get("Definition", ""),
-                "Example": strategy.get("Example", []),
-                "Score": strategy.get("Score", []),
-                "Embeddings": strategy.get("Embeddings", []),
+                **values,
             }
         if notify:
             self.logger.info(f"Strategy '{name}' updated (total: {len(self.library)})")
@@ -350,6 +240,11 @@ class StrategyLibrary:
         query_embedding = self.embed(query)
         if query_embedding is None:
             return True, []
+        try:
+            query_embedding = validate_embedding_vector(query_embedding)
+        except ValueError as exc:
+            self.logger.warning("Skipping retrieval: %s", exc)
+            return True, []
 
         # Collect all embeddings from all strategies
         all_embeddings, all_scores, all_examples, reverse_map = [], [], [], []
@@ -357,7 +252,14 @@ class StrategyLibrary:
             for i, emb in enumerate(s_info.get("Embeddings", [])):
                 if not isinstance(emb, np.ndarray):
                     continue
-                all_embeddings.append(emb.astype(np.float32))
+                try:
+                    emb = validate_embedding_vector(emb, dimension=query_embedding.size)
+                except ValueError as exc:
+                    self.logger.warning(
+                        "Skipping invalid embedding for %s: %s", s_name, exc
+                    )
+                    continue
+                all_embeddings.append(emb)
                 all_scores.append(s_info["Score"][i] if i < len(s_info["Score"]) else 0)
                 all_examples.append(
                     s_info["Example"][i] if i < len(s_info["Example"]) else ""
@@ -379,6 +281,8 @@ class StrategyLibrary:
         # Collect up to 2*k unique strategies (same as original)
         seen, retrieved = set(), {}
         for dist, idx in zip(distances, indices):
+            if idx < 0 or idx >= len(reverse_map) or not np.isfinite(dist):
+                continue
             s_name = reverse_map[idx]
             if s_name not in seen:
                 seen.add(s_name)
@@ -440,7 +344,14 @@ class StrategyLibrary:
             None.
         """
         with open(path + ".pkl", "wb") as f:
-            pickle.dump(self.library, f)
+            pickle.dump(
+                {
+                    "format": "hackagent-strategy-library-v1",
+                    "embedding_space": self._embedding_space(),
+                    "library": self.library,
+                },
+                f,
+            )
         self.logger.info(f"Strategy library saved to {path}.pkl")
 
     def load(self, path: str) -> None:
@@ -455,5 +366,35 @@ class StrategyLibrary:
         pkl = path if path.endswith(".pkl") else path + ".pkl"
         if os.path.exists(pkl):
             with open(pkl, "rb") as f:
-                self.library = pickle.load(f)
+                saved = pickle.load(f)
+            if saved.get("format") == "hackagent-strategy-library-v1":
+                self.library = saved["library"]
+                compatible = saved.get("embedding_space") == self._embedding_space()
+            else:
+                self.library = saved
+                # Old normal-config libraries contain hashed chat signatures.
+                compatible = (
+                    self._legacy_embedding_mode
+                    or self.embedding_model.startswith("local/")
+                )
+            if not compatible:
+                self.logger.warning(
+                    "Loaded library has an incompatible or unknown embedding space; "
+                    "discarding stored vectors. Rebuild the library for semantic retrieval."
+                )
+                for strategy in self.library.values():
+                    strategy["Embeddings"] = [None] * max(
+                        len(strategy.get(key, []))
+                        for key in ("Example", "Score", "Embeddings")
+                    )
             self.logger.info(f"Loaded {len(self.library)} strategies from {pkl}")
+
+    def _embedding_space(self) -> Dict[str, Any]:
+        """Persist provider identity, never credentials, to guard library reuse."""
+        if self.embedding_model.startswith("local/"):
+            return {"model": "local/bag-of-words", "dimension": 512}
+        config = {**self.embedder_config, "api_key": None}
+        kwargs = embedding_request_kwargs(config)
+        return {
+            key: kwargs.get(key) for key in ("model", "custom_llm_provider", "api_base")
+        }

--- a/hackagent/attacks/techniques/config.py
+++ b/hackagent/attacks/techniques/config.py
@@ -257,14 +257,45 @@ def default_category_classifier() -> Dict[str, Any]:
 def default_embedder() -> Dict[str, Any]:
     """Return a fresh embedder config dict (local ``embeddinggemma`` on Ollama).
 
-    Used by router-based embedder roles such as AutoDAN-Turbo strategy retrieval.
+    Used by embedding-only roles such as AutoDAN-Turbo strategy retrieval.
     """
     return {
         "identifier": DEFAULT_EMBEDDER_IDENTIFIER,
         "endpoint": DEFAULT_EMBEDDER_ENDPOINT,
         "agent_type": DEFAULT_EMBEDDER_AGENT_TYPE,
         "api_key": None,
+        "on_error": "disable",
     }
+
+
+def resolve_embedder_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge embedding defaults without leaking the Ollama base to other providers."""
+    if config is not None and not isinstance(config, dict):
+        raise ValueError("embedder must be a configuration dictionary")
+    resolved = default_embedder()
+    if config:
+        agent_type = config.get("agent_type", resolved["agent_type"])
+        agent_type = str(getattr(agent_type, "value", agent_type)).upper()
+        if agent_type != "OLLAMA":
+            resolved["endpoint"] = None
+        resolved.update(config)
+    if resolved.get("on_error") not in ("disable", "raise"):
+        raise ValueError("embedder.on_error must be 'disable' or 'raise'")
+    if (
+        not isinstance(resolved.get("identifier"), str)
+        or not resolved["identifier"].strip()
+    ):
+        raise ValueError("embedder.identifier must be a nonempty model name")
+    resolved["identifier"] = resolved["identifier"].strip()
+    agent_type = resolved.get("agent_type")
+    agent_type = str(getattr(agent_type, "value", agent_type)).upper()
+    if not resolved["identifier"].startswith("local/") and agent_type not in (
+        "OLLAMA",
+        "OPENAI_SDK",
+        "LITELLM",
+    ):
+        raise ValueError(f"Unsupported embedding agent_type: {agent_type}")
+    return resolved
 
 
 def default_rag_embedder() -> Dict[str, Any]:
@@ -398,6 +429,7 @@ __all__ = [
     "default_judge",
     "default_category_classifier",
     "default_embedder",
+    "resolve_embedder_config",
     "default_rag_embedder",
     "default_judges",
     "default_judge_eval",

--- a/hackagent/attacks/techniques/rag/attack.py
+++ b/hackagent/attacks/techniques/rag/attack.py
@@ -18,7 +18,6 @@ import glob
 import json
 import logging
 import math
-import os
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -227,16 +226,14 @@ def get_embeddings(
 ) -> np.ndarray:
     """Get embeddings using OpenAI-compatible API."""
     import openai
+    from hackagent.attacks.shared.embedding_utils import embedding_request_kwargs
 
-    api_key = config.get("api_key") or os.environ.get("OPENAI_API_KEY", "")
-    raw_endpoint = str(config.get("endpoint", "https://api.openai.com/v1")).strip()
-    endpoint = raw_endpoint.rstrip("/")
-    if endpoint.lower().endswith("/embeddings"):
-        # OpenAI client expects API base and appends '/embeddings' internally.
-        endpoint = endpoint[: -len("/embeddings")]
-    model = config.get("identifier", "embeddinggemma")
-
-    client = openai.OpenAI(api_key=api_key, base_url=endpoint)
+    kwargs = embedding_request_kwargs({"identifier": "embeddinggemma", **config})
+    model = kwargs["model"]
+    client = openai.OpenAI(
+        api_key=kwargs.get("api_key", ""),
+        base_url=kwargs.get("api_base", "https://api.openai.com/v1"),
+    )
 
     all_embeddings = []
     batch_size = 100  # OpenAI supports up to 2048, but be conservative

--- a/tests/unit/attacks/autodan_turbo/test_attack.py
+++ b/tests/unit/attacks/autodan_turbo/test_attack.py
@@ -50,6 +50,23 @@ class TestAttackHelpers(unittest.TestCase):
 
 
 class TestAutoDANTurboAttack(unittest.TestCase):
+    def test_openai_embedder_resolution_matches_preflight(self):
+        config = {
+            "embedder": {
+                "identifier": "text-embedding-3-small",
+                "agent_type": "OPENAI_SDK",
+                "on_error": "raise",
+            }
+        }
+        attack = AutoDANTurboAttack(
+            config=config, client=MagicMock(), agent_router=MagicMock()
+        )
+        roles = AutoDANTurboAttack.get_effective_model_roles(config)
+        embedder = next(role for role in roles if role["role"] == "embedder")
+        self.assertEqual(attack.config["embedder"], embedder["config"])
+        self.assertIsNone(attack.config["embedder"]["endpoint"])
+        self.assertFalse(embedder["required"])
+
     def test_init_requires_client_and_router(self):
         with self.assertRaises(ValueError):
             AutoDANTurboAttack(config={}, client=None, agent_router=MagicMock())

--- a/tests/unit/attacks/autodan_turbo/test_config.py
+++ b/tests/unit/attacks/autodan_turbo/test_config.py
@@ -6,6 +6,43 @@ from hackagent.attacks.techniques.autodan_turbo import config as autodan_config
 
 
 class TestAutoDANTurboConfig(unittest.TestCase):
+    def test_embedding_defaults_and_failure_policy(self):
+        from hackagent.attacks.techniques.config import default_embedder
+        from hackagent.attacks.techniques.autodan_turbo.strategy_library import (
+            StrategyLibrary,
+        )
+
+        defaults = default_embedder()
+        self.assertEqual(defaults["identifier"], "embeddinggemma")
+        self.assertEqual(defaults["on_error"], "disable")
+        self.assertEqual(StrategyLibrary().embedder_config, defaults)
+        self.assertEqual(autodan_config.AutoDANTurboConfig().embedder, defaults)
+        with self.assertRaises(ValidationError):
+            autodan_config.AutoDANTurboConfig(embedder={"on_error": "local"})
+        for invalid in (
+            {"identifier": ""},
+            {"identifier": None},
+            {"agent_type": "GOOGLE_ADK"},
+        ):
+            with self.subTest(invalid=invalid), self.assertRaises(ValidationError):
+                autodan_config.AutoDANTurboConfig(embedder=invalid)
+
+    def test_openai_embedder_does_not_inherit_ollama_endpoint(self):
+        config = autodan_config.AutoDANTurboConfig(
+            embedder={
+                "identifier": "text-embedding-3-small",
+                "agent_type": "OPENAI_SDK",
+            }
+        )
+        self.assertIsNone(config.embedder["endpoint"])
+        self.assertEqual(config.embedder["on_error"], "disable")
+        self.assertEqual(
+            autodan_config.AutoDANTurboConfig(embedder={"endpoint": None}).embedder[
+                "endpoint"
+            ],
+            None,
+        )
+
     def test_default_config_has_required_sections(self):
         cfg = autodan_config.DEFAULT_AUTODAN_TURBO_CONFIG
         self.assertEqual(cfg["attack_type"], "autodan_turbo")

--- a/tests/unit/attacks/autodan_turbo/test_strategy_library.py
+++ b/tests/unit/attacks/autodan_turbo/test_strategy_library.py
@@ -53,44 +53,149 @@ class TestStrategyLibrary(unittest.TestCase):
         self.assertEqual(lib.embedding_api_key, "k")
         self.assertEqual(lib.embedding_api_base, "http://base")
 
-    @patch("hackagent.attacks.techniques.autodan_turbo.strategy_library.create_router")
-    def test_embed_with_router_semantic_signature(self, mock_create_router):
-        router = MagicMock()
-        router.route_request.return_value = {"processed_response": "risk phishing bank"}
-        mock_create_router.return_value = (router, "embedder-key")
-
+    @patch("litellm.completion")
+    @patch("litellm.embedding")
+    def test_normal_embedder_uses_provider_vectors(self, mock_embedding, mock_chat):
+        mock_embedding.return_value = {"data": [{"embedding": [0.25, 0.75]}]}
+        backend = MagicMock()
         lib = StrategyLibrary(
             embedder_config={
-                "identifier": "gemma3:4b",
+                "identifier": "embeddinggemma:300m",
+                "endpoint": "http://localhost:11434",
+                "agent_type": "OLLAMA",
+            },
+            backend=backend,
+            logger=MagicMock(),
+        )
+        vec = lib.embed("retrieval context")
+        np.testing.assert_array_equal(vec, [0.25, 0.75])
+        self.assertEqual(vec.dtype, np.float32)
+        mock_embedding.assert_called_once_with(
+            model="openai/embeddinggemma:300m",
+            custom_llm_provider="openai",
+            api_base="http://localhost:11434/v1",
+            api_key="ollama",
+            encoding_format="float",
+            input=["retrieval context"],
+        )
+        mock_chat.assert_not_called()
+        self.assertEqual(backend.mock_calls, [])
+
+    @patch("litellm.embedding", side_effect=RuntimeError("HTTP 400: unsupported model"))
+    def test_external_failure_disables_without_local_fallback(self, mock_embedding):
+        lib = StrategyLibrary(
+            embedder_config={
+                "identifier": "embeddinggemma:300m",
                 "endpoint": "http://localhost:11434",
                 "agent_type": "OLLAMA",
             },
             backend=MagicMock(),
             logger=MagicMock(),
         )
-        vec = lib.embed("how to steal credentials")
+        with patch.object(lib, "_local_embed") as mock_local:
+            self.assertIsNone(lib.embed("external failure"))
+            self.assertIsNone(lib.embed("later request"))
+        mock_local.assert_not_called()
+        mock_embedding.assert_called_once()
+        lib.logger.error.assert_called_once()
 
-        self.assertIsInstance(vec, np.ndarray)
-        self.assertEqual(vec.dtype, np.float32)
-        router.route_request.assert_called_once()
+    @patch("litellm.embedding", side_effect=RuntimeError("unreachable"))
+    def test_explicit_raise_policy(self, mock_embedding):
+        lib = StrategyLibrary(embedder_config={"on_error": "raise"}, logger=MagicMock())
+        with self.assertRaisesRegex(RuntimeError, "unreachable"):
+            lib.embed("query")
 
-    @patch(
-        "hackagent.attacks.techniques.autodan_turbo.strategy_library.create_router",
-        side_effect=RuntimeError("router init failed"),
-    )
-    def test_embedder_router_init_failure_falls_back_local(self, _mock_create_router):
-        lib = StrategyLibrary(
-            embedder_config={
-                "identifier": "gemma3:4b",
-                "endpoint": "http://localhost:11434",
-                "agent_type": "OLLAMA",
-            },
-            backend=MagicMock(),
-            logger=MagicMock(),
+    @patch("litellm.embedding")
+    def test_local_modes_need_no_provider_or_credentials(self, mock_embedding):
+        for kwargs in (
+            {"embedder_config": {"identifier": "local/bag-of-words"}},
+            {"embedding_model": "local/bag-of-words"},
+            {"embedding_api_key": "legacy-key-only"},
+        ):
+            with self.subTest(kwargs=kwargs):
+                lib = StrategyLibrary(**kwargs)
+                vector = lib.embed("same text")
+                self.assertEqual(vector.shape, (512,))
+                np.testing.assert_array_equal(vector, lib.embed("same text"))
+        mock_embedding.assert_not_called()
+
+    @patch("litellm.embedding")
+    def test_provider_vectors_drive_real_faiss_retrieval(self, mock_embedding):
+        mock_embedding.side_effect = [
+            {"data": [{"embedding": vector}]}
+            for vector in ([10.0, 0.0], [0.0, 1.0], [0.0, 0.9])
+        ]
+        lib = StrategyLibrary(logger=MagicMock())
+        for name in ("far", "near"):
+            lib.add(
+                {
+                    "Strategy": name,
+                    "Score": [6.0],
+                    "Example": [name],
+                    "Embeddings": [lib.embed(name)],
+                }
+            )
+        valid, result = lib.retrieve("query")
+        self.assertTrue(valid)
+        self.assertEqual(result[0]["Strategy"], "near")
+        self.assertEqual(mock_embedding.call_count, 3)
+
+    @patch("litellm.embedding")
+    def test_dimension_change_disables_retrieval(self, mock_embedding):
+        mock_embedding.side_effect = [
+            {"data": [{"embedding": [0.0, 1.0]}]},
+            {"data": [{"embedding": [0.0, 1.0, 2.0]}]},
+        ]
+        lib = StrategyLibrary(logger=MagicMock())
+        self.assertIsNotNone(lib.embed("first"))
+        self.assertIsNone(lib.embed("second"))
+        self.assertIn("dimension changed", lib._embedding_disabled_reason)
+
+    @patch("litellm.embedding")
+    def test_malformed_responses_never_fall_back(self, mock_embedding):
+        for response in (
+            None,
+            {},
+            {"data": []},
+            {"choices": [{"text": "signature"}]},
+            {"data": [{"embedding": []}]},
+            {"data": [{"embedding": [float("nan")]}]},
+        ):
+            with self.subTest(response=response):
+                mock_embedding.return_value = response
+                lib = StrategyLibrary(logger=MagicMock())
+                self.assertIsNone(lib.embed("query"))
+                self.assertIsNotNone(lib._embedding_disabled_reason)
+
+    def test_retrieval_skips_invalid_stored_vectors_and_preserves_score_alignment(self):
+        lib = StrategyLibrary(logger=MagicMock())
+        lib.embed = MagicMock(return_value=np.array([0.0, 1.0], dtype=np.float32))
+        invalid = [
+            np.array([]),
+            np.array([0.0]),
+            np.array([[0.0, 1.0]]),
+            np.array([float("nan"), 1.0]),
+            np.array([float("inf"), 1.0]),
+        ]
+        lib.add(
+            {
+                "Strategy": "valid",
+                "Embeddings": invalid + [np.array([0.0, 1.0])],
+                "Score": [0] * len(invalid) + [6],
+                "Example": ["bad"] * len(invalid) + ["correct"],
+            }
         )
-        vec = lib.embed("fallback local embedding")
-        self.assertIsInstance(vec, np.ndarray)
-        self.assertEqual(vec.dtype, np.float32)
+        valid, result = lib.retrieve("query")
+        self.assertTrue(valid)
+        self.assertEqual(result[0]["Example"], "correct")
+
+    def test_retrieval_rejects_invalid_query_before_faiss(self):
+        lib = StrategyLibrary(logger=MagicMock())
+        lib.add({"Strategy": "S", "Embeddings": [np.array([1.0, 2.0])]})
+        for value in ([], [[1.0, 2.0]], [float("nan"), 1.0]):
+            with self.subTest(value=value):
+                lib.embed = MagicMock(return_value=np.array(value))
+                self.assertEqual(lib.retrieve("query"), (True, []))
 
     def test_add_merge_all_size(self):
         lib = StrategyLibrary(logger=MagicMock())
@@ -117,6 +222,24 @@ class TestStrategyLibrary(unittest.TestCase):
         logger.info.reset_mock()  # ignore the init-time "Embedding backend" log
         lib.add({"Strategy": "S", "Definition": "D"}, notify=True)
         logger.info.assert_called_once()
+
+    def test_missing_embeddings_keep_examples_and_scores_aligned_on_merge(self):
+        lib = StrategyLibrary(logger=MagicMock())
+        lib.add(
+            {"Strategy": "S", "Example": ["failed"], "Score": [0], "Embeddings": []}
+        )
+        lib.add(
+            {
+                "Strategy": "S",
+                "Example": ["success"],
+                "Score": [6],
+                "Embeddings": [np.array([0.0, 1.0])],
+            }
+        )
+        lib.embed = MagicMock(return_value=np.array([0.0, 1.0]))
+        valid, result = lib.retrieve("query")
+        self.assertTrue(valid)
+        self.assertEqual(result[0]["Example"], "success")
 
     @patch("litellm.embedding")
     def test_embed_success(self, mock_litellm_embedding):
@@ -369,12 +492,94 @@ class TestStrategyLibrary(unittest.TestCase):
             }
         }
 
-        with tempfile.TemporaryDirectory() as td:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as td:
             path = f"{td}/strategy_lib"
             lib.save(path)
             lib2 = StrategyLibrary(logger=MagicMock())
             lib2.load(path)
             self.assertIn("S", lib2.library)
+
+    def test_saved_vectors_are_only_reused_in_same_space(self):
+        lib = StrategyLibrary(embedding_model="local/bag-of-words", logger=MagicMock())
+        lib.add(
+            {
+                "Strategy": "S",
+                "Score": [6],
+                "Example": ["example"],
+                "Embeddings": [lib.embed("example")],
+            }
+        )
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as td:
+            path = f"{td}/strategy_lib"
+            lib.save(path)
+            compatible = StrategyLibrary(embedding_model="local/bag-of-words")
+            compatible.load(path)
+            np.testing.assert_array_equal(
+                compatible.library["S"]["Embeddings"][0],
+                lib.library["S"]["Embeddings"][0],
+            )
+            incompatible = StrategyLibrary(logger=MagicMock())
+            incompatible.load(path)
+            self.assertEqual(incompatible.library["S"]["Embeddings"], [None])
+            self.assertEqual(incompatible.library["S"]["Example"], ["example"])
+
+    def test_unversioned_normal_library_does_not_reuse_chat_hashes(self):
+        import pickle
+
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as td:
+            path = f"{td}/strategy_lib.pkl"
+            with open(path, "wb") as file:
+                pickle.dump(
+                    {
+                        "S": {
+                            "Embeddings": [np.zeros(512)],
+                            "Score": [6],
+                            "Example": ["old"],
+                        }
+                    },
+                    file,
+                )
+            lib = StrategyLibrary(logger=MagicMock())
+            lib.load(path)
+            self.assertEqual(lib.library["S"]["Embeddings"], [None])
+
+    def test_provider_space_metadata_normalizes_urls_and_never_stores_keys(self):
+        config = {
+            "identifier": "embeddinggemma:300m",
+            "agent_type": "OLLAMA",
+            "endpoint": "http://ollama.test/api/embed",
+            "api_key": "secret-embedding-key",
+        }
+        lib = StrategyLibrary(embedder_config=config)
+        lib.add(
+            {
+                "Strategy": "S",
+                "Score": [6],
+                "Example": ["example"],
+                "Embeddings": [np.array([0.0, 1.0])],
+            }
+        )
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as td:
+            path = f"{td}/strategy_lib"
+            lib.save(path)
+            self.assertNotIn(b"secret-embedding-key", Path(path + ".pkl").read_bytes())
+            compatible = StrategyLibrary(
+                embedder_config={
+                    **config,
+                    "endpoint": "http://ollama.test/v1",
+                    "api_key": "rotated-key",
+                }
+            )
+            compatible.load(path)
+            np.testing.assert_array_equal(
+                compatible.library["S"]["Embeddings"][0], [0.0, 1.0]
+            )
+            incompatible = StrategyLibrary(
+                embedder_config={**config, "identifier": "other-model"},
+                logger=MagicMock(),
+            )
+            incompatible.load(path)
+            self.assertEqual(incompatible.library["S"]["Embeddings"], [None])
 
     def test_load_missing_file_noop(self):
         lib = StrategyLibrary(logger=MagicMock())

--- a/tests/unit/attacks/rag/test_helpers.py
+++ b/tests/unit/attacks/rag/test_helpers.py
@@ -174,6 +174,36 @@ class TestParseDocuments(unittest.TestCase):
 
 
 class TestGetEmbeddings(unittest.TestCase):
+    def test_uses_shared_embedding_endpoint_and_credential_resolution(self):
+        from hackagent.attacks.shared.embedding_utils import embedding_request_kwargs
+
+        for config in (
+            {
+                "identifier": "embeddinggemma",
+                "agent_type": "OLLAMA",
+                "endpoint": "http://x/api/embed",
+            },
+            {
+                "identifier": "openai/text-embedding-3-small",
+                "endpoint": "https://example.test",
+                "api_key": "${EMBED_KEY}",
+            },
+        ):
+            with (
+                self.subTest(config=config),
+                patch.dict("os.environ", {"EMBED_KEY": "embedding-key"}, clear=True),
+            ):
+                kwargs = embedding_request_kwargs(config)
+                fake_client = self._fake_client()
+                with patch("openai.OpenAI", return_value=fake_client) as mock_client:
+                    get_embeddings(["a"], config, LOGGER)
+                mock_client.assert_called_once_with(
+                    api_key=kwargs["api_key"], base_url=kwargs["api_base"]
+                )
+                fake_client.embeddings.create.assert_called_once_with(
+                    input=["a"], model=kwargs["model"]
+                )
+
     def _fake_client(self, dim=4):
         fake_client = MagicMock()
 

--- a/tests/unit/attacks/shared/test_embedding_utils.py
+++ b/tests/unit/attacks/shared/test_embedding_utils.py
@@ -1,0 +1,426 @@
+# Copyright 2026 - AI4I. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Offline embedding provider and response validation regression tests."""
+
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import numpy as np
+import pytest
+
+from hackagent.attacks.shared.embedding_utils import (
+    embedding_request_kwargs,
+    extract_embedding_vector,
+    normalize_embedding_endpoint,
+    request_embedding,
+)
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "",
+        "/",
+        "/v1",
+        "/v1/",
+        "/v1/embeddings",
+        "/v1/embeddings/",
+        "/api/embed",
+        "/api/embeddings",
+    ],
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        "embeddinggemma:300m",
+        "ollama/embeddinggemma:300m",
+        "ollama_chat/embeddinggemma:300m",
+    ],
+)
+def test_ollama_endpoint_and_prefix_normalization(suffix, model):
+    kwargs = embedding_request_kwargs(
+        {
+            "identifier": model,
+            "endpoint": "http://ollama.test/proxy" + suffix,
+            "agent_type": "OLLAMA",
+        }
+    )
+    assert kwargs == {
+        "model": "embeddinggemma:300m",
+        "custom_llm_provider": "openai",
+        "encoding_format": "float",
+        "api_base": "http://ollama.test/proxy/v1",
+        "api_key": "ollama",
+    }
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ("https://example.test", "https://example.test/v1"),
+        ("https://example.test/v1/", "https://example.test/v1"),
+        ("https://example.test/v1/embeddings/", "https://example.test/v1"),
+        ("https://example.test/api/v1/embeddings", "https://example.test/api/v1"),
+        ("https://example.test/custom", "https://example.test/custom"),
+        ("https://example.test/embeddings", "https://example.test"),
+    ],
+)
+def test_compatible_endpoint_normalization(endpoint, expected):
+    assert normalize_embedding_endpoint(endpoint) == expected
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("explicit-key", "explicit-key"),
+        ("EMBEDDING_KEY", "environment-key"),
+        ("${EMBEDDING_KEY}", "environment-key"),
+        (None, "openai-key"),
+    ],
+)
+def test_openai_keys(configured, expected):
+    with patch.dict(
+        "os.environ",
+        {"EMBEDDING_KEY": "environment-key", "OPENAI_API_KEY": "openai-key"},
+        clear=True,
+    ):
+        kwargs = embedding_request_kwargs(
+            {
+                "identifier": "openai/text-embedding-3-small",
+                "agent_type": "OPENAI_SDK",
+                "api_key": configured,
+            }
+        )
+    assert kwargs["api_key"] == expected
+    assert kwargs["model"] == "text-embedding-3-small"
+    assert "api_base" not in kwargs
+
+
+def test_no_storage_key_fallback_and_unset_env_reference():
+    with patch.dict("os.environ", {"HACKAGENT_API_KEY": "storage-token"}, clear=True):
+        kwargs = embedding_request_kwargs({"identifier": "text-embedding-3-small"})
+        assert "api_key" not in kwargs
+        with pytest.raises(ValueError, match="is unset"):
+            embedding_request_kwargs(
+                {"identifier": "model", "api_key": "${MISSING_KEY}"}
+            )
+
+
+def test_ollama_explicit_auth_and_slash_model_preserved():
+    kwargs = embedding_request_kwargs(
+        {
+            "identifier": "org/embedding-model",
+            "agent_type": "OLLAMA",
+            "api_key": "ollama-auth",
+        }
+    )
+    assert kwargs["model"] == "org/embedding-model"
+    assert kwargs["api_key"] == "ollama-auth"
+
+
+def test_litellm_provider_prefix_preserved():
+    kwargs = embedding_request_kwargs(
+        {
+            "identifier": "cohere/embed-english-v3.0",
+            "agent_type": "LITELLM",
+        }
+    )
+    assert kwargs["model"] == "cohere/embed-english-v3.0"
+    assert "custom_llm_provider" not in kwargs
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        [],
+        "signature",
+        ["1"],
+        [True],
+        [[1, 2]],
+        [float("nan")],
+        [float("inf")],
+        [-float("inf")],
+        [1e40],
+        [1 + 2j],
+        [None],
+    ],
+)
+def test_invalid_embedding_vectors(value):
+    with pytest.raises(ValueError):
+        extract_embedding_vector({"data": [{"embedding": value}]})
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        {},
+        {"data": []},
+        {"data": "bad"},
+        {"data": [{}, {}]},
+        {"embeddings": [[1, 2]]},
+    ],
+)
+def test_malformed_embedding_payload(response):
+    with pytest.raises(ValueError):
+        extract_embedding_vector(response)
+
+
+def test_object_response_validation():
+    vector = extract_embedding_vector(
+        SimpleNamespace(data=[SimpleNamespace(embedding=[0.25, 1])])
+    )
+    np.testing.assert_array_equal(vector, [0.25, 1])
+    assert vector.dtype == np.float32
+
+
+@pytest.mark.parametrize("suffix", ["", "/v1", "/v1/embeddings", "/api/embed"])
+def test_real_litellm_dispatch_uses_compatible_embedding_http_request(
+    suffix, embedding_http_transport
+):
+    """Mock HTTP transport, not LiteLLM: exercise SDK URL construction offline."""
+    vector = request_embedding(
+        {
+            "identifier": "ollama/embeddinggemma:300m",
+            "agent_type": "OLLAMA",
+            "endpoint": "http://embedding.test" + suffix,
+        },
+        "text to embed",
+    )
+    np.testing.assert_array_equal(vector, [0.25, 0.75])
+    assert len(embedding_http_transport) == 1
+    request = embedding_http_transport[0]
+    assert str(request.url) == "http://embedding.test/v1/embeddings"
+    payload = json.loads(request.content)
+    assert payload["input"] == ["text to embed"]
+    assert payload["model"] == "embeddinggemma:300m"
+    assert "messages" not in payload
+
+
+_LITELLM_COST_MAP_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/"
+    "model_prices_and_context_window.json"
+)
+
+
+@pytest.fixture(scope="module")
+def local_litellm_cost_map():
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+    return GetModelCostMap.load_local_model_cost_map()
+
+
+@pytest.fixture
+def embedding_http_transport(monkeypatch, local_litellm_cost_map):
+    """Intercept real SDK requests; no provider or embedding function is mocked."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    requests = []
+    unexpected_requests = []
+
+    def send(_client, request, **kwargs):
+        # A refresh started by another test can already be in flight before the
+        # environment flag takes effect. Serve bundled prices, never the network.
+        if request.method == "GET" and str(request.url) == _LITELLM_COST_MAP_URL:
+            return httpx.Response(200, request=request, json=local_litellm_cost_map)
+        if request.method != "POST" or not request.url.path.endswith("/embeddings"):
+            unexpected_requests.append((request.method, str(request.url)))
+            raise AssertionError(
+                f"Unexpected network request: {unexpected_requests[-1]}"
+            )
+        requests.append(request)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "object": "list",
+                "model": json.loads(request.content)["model"],
+                "data": [
+                    {"object": "embedding", "index": 0, "embedding": [0.25, 0.75]}
+                ],
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+        )
+
+    with patch.object(httpx.Client, "send", send):
+        yield requests
+    assert not unexpected_requests
+
+
+def test_embedding_transport_isolates_concurrent_cost_map_refresh(
+    embedding_http_transport, local_litellm_cost_map
+):
+    """Reproduce an already-started refresh that bypasses the environment guard."""
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        refresh = executor.submit(
+            GetModelCostMap.fetch_remote_model_cost_map, _LITELLM_COST_MAP_URL
+        )
+        vector = request_embedding(
+            {
+                "identifier": "openai/text-embedding-3-small",
+                "agent_type": "OPENAI_SDK",
+                "endpoint": "https://compatible.test/v1",
+                "api_key": "offline-provider-key",
+            },
+            "text to embed",
+        )
+        assert refresh.result() == local_litellm_cost_map
+    np.testing.assert_array_equal(vector, [0.25, 0.75])
+    assert len(embedding_http_transport) == 1
+    request = embedding_http_transport[0]
+    assert str(request.url) == "https://compatible.test/v1/embeddings"
+    assert json.loads(request.content)["model"] == "openai/text-embedding-3-small"
+
+
+@pytest.mark.parametrize("consumer", ["autodan", "rag", "preflight", "legacy"])
+@pytest.mark.parametrize(
+    "endpoint", ["https://openrouter.ai/api/v1", "https://compatible.test/custom/v1"]
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openai/text-embedding-3-small",
+        "acme/embedding-model",
+        "azure/native-model",
+        "ollama/native-model",
+    ],
+)
+def test_compatible_transport_preserves_server_model_names(
+    consumer, endpoint, model, embedding_http_transport
+):
+    from hackagent.attacks.orchestrator import AttackOrchestrator
+    from hackagent.attacks.techniques.autodan_turbo.strategy_library import (
+        StrategyLibrary,
+    )
+    from hackagent.attacks.techniques.rag.attack import get_embeddings
+
+    config = {
+        "identifier": model,
+        "agent_type": "OPENAI_SDK",
+        "endpoint": endpoint,
+        "api_key": "compatible-provider-key",
+    }
+    if consumer == "autodan":
+        vector = StrategyLibrary(embedder_config=config).embed("text to embed")
+        np.testing.assert_array_equal(vector, [0.25, 0.75])
+    elif consumer == "rag":
+        vectors = get_embeddings(["text to embed"], config, logging.getLogger(__name__))
+        np.testing.assert_array_equal(vectors, [[0.25, 0.75]])
+    elif consumer == "legacy":
+        vector = StrategyLibrary(
+            embedding_model=f"openai/{model}",
+            embedding_api_base=endpoint,
+            embedding_api_key="compatible-provider-key",
+        ).embed("text to embed")
+        np.testing.assert_array_equal(vector, [0.25, 0.75])
+    else:
+        orchestrator = object.__new__(AttackOrchestrator)
+        assert orchestrator._probe_embedding_target({"config": config}) is None
+
+    assert len(embedding_http_transport) == 1
+    request = embedding_http_transport[0]
+    assert str(request.url) == f"{endpoint}/embeddings"
+    assert json.loads(request.content)["model"] == model
+    assert request.headers["Authorization"] == "Bearer compatible-provider-key"
+
+
+@pytest.mark.parametrize("mode", ["normal", "legacy"])
+@pytest.mark.parametrize("path", ["", "/proxy"])
+def test_native_azure_transport_preserves_provider_base(
+    mode, path, embedding_http_transport
+):
+    from hackagent.attacks.techniques.autodan_turbo.strategy_library import (
+        StrategyLibrary,
+    )
+
+    endpoint = f"https://embedding-resource.openai.azure.com{path}"
+    if mode == "legacy":
+        library = StrategyLibrary(
+            embedding_model="azure/embedding-deployment",
+            embedding_api_base=endpoint,
+            embedding_api_key="azure-provider-key",
+        )
+    else:
+        library = StrategyLibrary(
+            embedder_config={
+                "identifier": "azure/embedding-deployment",
+                "agent_type": "LITELLM",
+                "endpoint": endpoint,
+                "api_key": "azure-provider-key",
+            }
+        )
+    with patch.dict("os.environ", {"AZURE_API_VERSION": "2024-02-01"}):
+        np.testing.assert_array_equal(library.embed("text to embed"), [0.25, 0.75])
+    assert len(embedding_http_transport) == 1
+    request = embedding_http_transport[0]
+    assert (
+        request.url.path == f"{path}/openai/deployments/embedding-deployment/embeddings"
+    )
+    assert request.url.params["api-version"] == "2024-02-01"
+    assert json.loads(request.content)["model"] == "embedding-deployment"
+    assert request.headers["api-key"] == "azure-provider-key"
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["azure/deployment", "cohere/embed-v3", "bedrock/amazon.titan-embed-text-v2:0"],
+)
+@pytest.mark.parametrize(
+    "endpoint", ["https://native.test", "https://native.test/embeddings"]
+)
+def test_native_litellm_bases_are_not_openai_normalized(model, endpoint):
+    kwargs = embedding_request_kwargs(
+        {
+            "identifier": model,
+            "agent_type": "LITELLM",
+            "endpoint": endpoint,
+            "api_key": "native-key",
+        }
+    )
+    assert kwargs["api_base"] == endpoint
+    assert kwargs["model"] == model
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://api.openai.com",
+        "https://api.openai.com/v1",
+        "https://api.openai.com/v1/embeddings",
+    ],
+)
+@pytest.mark.parametrize("mode", ["normal", "legacy"])
+def test_openai_transport_still_removes_only_routing_prefix(
+    endpoint, mode, embedding_http_transport
+):
+    from hackagent.attacks.techniques.autodan_turbo.strategy_library import (
+        StrategyLibrary,
+    )
+
+    if mode == "legacy":
+        library = StrategyLibrary(
+            embedding_model="openai/text-embedding-3-small",
+            embedding_api_base=endpoint,
+            embedding_api_key="openai-provider-key",
+        )
+    else:
+        library = StrategyLibrary(
+            embedder_config={
+                "identifier": "openai/text-embedding-3-small",
+                "agent_type": "OPENAI_SDK",
+                "endpoint": endpoint,
+                "api_key": "openai-provider-key",
+            }
+        )
+    np.testing.assert_array_equal(library.embed("text to embed"), [0.25, 0.75])
+    assert len(embedding_http_transport) == 1
+    request = embedding_http_transport[0]
+    assert str(request.url) == "https://api.openai.com/v1/embeddings"
+    assert json.loads(request.content)["model"] == "text-embedding-3-small"
+    assert request.headers["Authorization"] == "Bearer openai-provider-key"

--- a/tests/unit/attacks/test_orchestrator_extended.py
+++ b/tests/unit/attacks/test_orchestrator_extended.py
@@ -740,6 +740,157 @@ class TestDefaultCategoryClassifierPreflight(unittest.TestCase):
 class TestRequiredModelAvailabilityPreflight(unittest.TestCase):
     """Test fail-fast behavior for model availability preflight."""
 
+    @patch("litellm.embedding", return_value={"data": [{"embedding": [0.25, 0.75]}]})
+    def test_embedding_probe_uses_runtime_provider_path(self, mock_embedding):
+        orch, _, _ = _make_orchestrator()
+        for endpoint in (
+            "http://ollama.test",
+            "http://ollama.test/v1",
+            "http://ollama.test/api/embed",
+            "http://ollama.test/v1/embeddings",
+        ):
+            with (
+                self.subTest(endpoint=endpoint),
+                patch.object(orch, "_probe_router_registration") as mock_chat,
+            ):
+                error = orch._probe_model_target(
+                    {
+                        "role": "embedder",
+                        "kind": "router_config",
+                        "identifier": "ollama/embeddinggemma:300m",
+                        "agent_type": "OLLAMA",
+                        "endpoint": endpoint,
+                    }
+                )
+                self.assertIsNone(error)
+                self.assertEqual(
+                    mock_embedding.call_args.kwargs["api_base"], "http://ollama.test/v1"
+                )
+                self.assertEqual(
+                    mock_embedding.call_args.kwargs["input"], ["healthcheck"]
+                )
+                self.assertEqual(mock_embedding.call_args.kwargs["timeout"], 20.0)
+                mock_chat.assert_not_called()
+
+    @patch("litellm.embedding")
+    def test_embedding_probe_requires_vector_not_model_presence_or_http_success(
+        self, mock_embedding
+    ):
+        orch, _, _ = _make_orchestrator()
+        target = {
+            "role": "embedder",
+            "kind": "router_config",
+            "identifier": "embeddinggemma:300m",
+            "agent_type": "OLLAMA",
+        }
+        for response in (
+            {},
+            {"models": [{"name": "embeddinggemma:300m"}]},
+            {"data": []},
+            {"data": [{"embedding": []}]},
+            {"data": [{"embedding": [float("inf")]}]},
+        ):
+            with self.subTest(response=response):
+                mock_embedding.return_value = response
+                self.assertIn(
+                    "embedding health check failed", orch._probe_model_target(target)
+                )
+        mock_embedding.side_effect = RuntimeError(
+            "HTTP 400: does not support embeddings"
+        )
+        self.assertIn("HTTP 400", orch._probe_model_target(target))
+
+    @patch("litellm.embedding", return_value={"data": [{"embedding": [0.0, 1.0]}]})
+    def test_embedding_probe_provider_default_endpoint_and_env_credentials(
+        self, mock_embedding
+    ):
+        orch, _, _ = _make_orchestrator()
+        with patch.dict(os.environ, {"EMBED_KEY": "provider-key"}, clear=True):
+            self.assertIsNone(
+                orch._probe_model_target(
+                    {
+                        "role": "embedder",
+                        "kind": "router_config",
+                        "config": {
+                            "identifier": "text-embedding-3-small",
+                            "agent_type": "OPENAI_SDK",
+                            "api_key": "${EMBED_KEY}",
+                        },
+                    }
+                )
+            )
+        self.assertEqual(mock_embedding.call_args.kwargs["api_key"], "provider-key")
+        self.assertNotIn("api_base", mock_embedding.call_args.kwargs)
+
+    @patch("litellm.embedding")
+    def test_explicit_local_embedding_needs_no_network_or_ollama_pull(
+        self, mock_embedding
+    ):
+        orch, _, _ = _make_orchestrator()
+        target = {
+            "role": "embedder",
+            "kind": "router_config",
+            "identifier": "local/bag-of-words",
+            "agent_type": "OLLAMA",
+        }
+        with patch.object(orch, "_get_installed_ollama_models") as mock_models:
+            orch._autopull_missing_ollama_targets([target])
+            self.assertIsNone(orch._probe_model_target(target))
+        mock_models.assert_not_called()
+        mock_embedding.assert_not_called()
+
+    def test_chat_and_embedding_capabilities_are_not_deduplicated(self):
+        orch, _, _ = _make_orchestrator()
+        orch.attack_impl_class = AutoDANTurboAttack
+        orch.hackagent_agent.router = None
+        role = {
+            "identifier": "same-model",
+            "endpoint": "http://ollama.test",
+            "agent_type": "OLLAMA",
+        }
+        targets = orch._collect_model_preflight_targets(
+            {
+                "attacker": role,
+                "embedder": role,
+            },
+            goal_labels_by_index={0: {"category": "c", "subcategory": "s"}},
+        )
+        self.assertEqual(len(targets), 2)
+        self.assertEqual(
+            [target["roles"] for target in targets], [["attacker"], ["embedder"]]
+        )
+        self.assertTrue(targets[0]["required"])
+        self.assertFalse(targets[1]["required"])
+
+    @patch("hackagent.attacks.orchestrator.shutil.which", return_value="/mock/ollama")
+    def test_embedding_autopull_uses_native_model_name(self, _mock_which):
+        orch, _, _ = _make_orchestrator()
+        with (
+            patch.object(orch, "_get_installed_ollama_models", return_value=set()),
+            patch.object(orch, "_pull_ollama_model", return_value=True) as mock_pull,
+        ):
+            orch._autopull_missing_ollama_targets(
+                [
+                    {
+                        "role": "embedder",
+                        "agent_type": "OLLAMA",
+                        "identifier": "ollama/embeddinggemma:300m",
+                    }
+                ]
+            )
+        mock_pull.assert_called_once_with("embeddinggemma:300m")
+
+    def test_default_embedder_is_optional_unless_explicitly_required(self):
+        from hackagent.attacks.techniques.config import default_embedder
+
+        for required in (False, True):
+            roles = AutoDANTurboAttack.get_effective_model_roles(
+                {"_preflight_require_embedder": required}
+            )
+            embedder = next(role for role in roles if role["role"] == "embedder")
+            self.assertEqual(embedder["required"], required)
+            self.assertEqual(embedder["config"], default_embedder())
+
     def test_normalize_attack_type_for_preflight_accepts_autodan_aliases(self):
         """AutoDAN aliases should resolve to autodan_turbo mapping key."""
         orch, _, _ = _make_orchestrator()


### PR DESCRIPTION
## Summary
Fixes #566.

- Use real embedding requests/vectors for the normal AutoDAN embedder configuration instead of sending chat messages to embedding-only models or hashing textual signatures.
- Share provider-aware endpoint, credential, and vector handling across retrieval and embedding preflight; reuse compatible normalization in RAG.
- Support Ollama-compatible embedding endpoints, official/custom OpenAI-compatible servers, and native LiteLLM providers. Preserve server model namespaces and Azure deployment endpoint paths.
- Validate nonempty finite vectors, dimensions, and persisted-library compatibility; correct embedder defaults without changing optional preflight semantics.

## Behavior and compatibility
- Configured external embeddings no longer silently switch to local hashing on errors. Default `embedder.on_error="disable"` logs the failure and continues without semantic retrieval; `"raise"` propagates runtime errors.
- Deterministic offline retrieval remains available explicitly through `local/bag-of-words`.
- Legacy embedding constructor arguments remain supported. Libraries made from old chat signatures must be rebuilt for native embeddings; provider/model/base metadata prevents mixing incompatible vector spaces.
- Provider credentials never fall back to the HackAgent storage token. Custom compatible model IDs retain their namespace; native LiteLLM/Azure bases are not rewritten as OpenAI URLs.

## Validation
- 349 targeted tests passed before the final HTTP-isolation regression; the complete unit suite passed twice after it and again in the required commit hook on latest main.
- Real LiteLLM/OpenAI clients exercised through mocked HTTP transport: Ollama URL variants, OpenRouter/custom namespaces, Azure, official OpenAI, legacy constructors, RAG and preflight.
- Tests cover malformed/empty/nonfinite vectors, dimension changes, saved libraries, explicit failure modes, defaults, local retrieval, and credential resolution.
- Background LiteLLM pricing refreshes are served from bundled data during transport tests; unexpected network requests fail explicitly.
- Ruff lint/format, diff hygiene, and all commit hooks passed. Independent review verified both provider-dispatch corrections.

No new dependencies or live model requests are required for the tests.